### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,6 +3,9 @@
 
 name: Python package
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/kejhy93/ProteinFolding/security/code-scanning/2](https://github.com/kejhy93/ProteinFolding/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained.  
Best fix here (without changing functionality): add workflow-level permissions with `contents: read`, since all jobs in this file are read-only CI tasks (checkout, install, lint, test). This preserves behavior while preventing accidental write-capable token usage.

Edit file: `.github/workflows/python-package.yml`  
Change region: near the top-level keys (`name`, `on`, `jobs`)  
Add:
- `permissions:`
- `  contents: read`

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add an explicit permissions block to the Python package GitHub Actions workflow to limit GITHUB_TOKEN to contents: read.