### PR TITLE
Rename Ant.__init__ parameter ID to ant_id

### DIFF
--- a/data/ant.py
+++ b/data/ant.py
@@ -29,9 +29,9 @@ CHANGE_RATE = 0
 
 
 class Ant(Thread):
-    def __init__(self, ID, sequance, pheronome, heuristic_val, pheronome_val):
+    def __init__(self, ant_id, sequance, pheronome, heuristic_val, pheronome_val):
         Thread.__init__(self)
-        self.ID = ID
+        self.ID = ant_id
 
         # configuration
         self.vector = Vector(sequance)


### PR DESCRIPTION
Fixes SonarCloud python:S117 (naming convention) at data/ant.py:32.

## Summary by Sourcery

Enhancements:
- Standardize Ant.__init__ argument naming by renaming ID to ant_id while preserving existing self.ID usage.