### PR TITLE
Split Ant.sort_by into selection_sort and randomize_equal_solutions

### DIFF
--- a/data/ant.py
+++ b/data/ant.py
@@ -163,6 +163,15 @@ class Ant(Thread):
         """
         Sort computed probabilities by select sort
         """
+        indexes, values = self.selection_sort(indexes, values)
+        indexes, values = self.randomize_equal_solutions(indexes, values)
+
+        return indexes, values
+
+    def selection_sort(self, indexes, values):
+        """
+        Sort indexes/values in place by select sort
+        """
         comparator = self.compare
 
         for index in range(len(indexes) - 1, 0, -1):
@@ -173,22 +182,29 @@ class Ant(Thread):
 
             indexes, values = self.swap(indexes, values, index, lowest_index)
 
-        # Ant colony returns equal solution
-        # Make some random change
+        return indexes, values
+
+    def randomize_equal_solutions(self, indexes, values):
+        """
+        Ant colony returns equal solution, make some random change
+        """
         change = 0
         # Iterate probability list
         for index in range(len(indexes) - 1):
             # Check if two probabilities are almost equal
-            if random.random() < 0.2:
-                if self.little_diference(values[index], values[index + 1]) and change < CHANGE_RATE:
-                    switch_probability = random.random()
-                    # Check probability
-                    if switch_probability < SWITCH_PROBABILITY:
-                        # Swap two probabilities
-                        print("Swap")
-                        indexes, values = self.swap(indexes, values, index, index + 1)
+            if not (random.random() < 0.2):
+                continue
+            if not (self.little_diference(values[index], values[index + 1]) and change < CHANGE_RATE):
+                continue
 
-                        change -= 1
+            switch_probability = random.random()
+            # Check probability
+            if switch_probability < SWITCH_PROBABILITY:
+                # Swap two probabilities
+                print("Swap")
+                indexes, values = self.swap(indexes, values, index, index + 1)
+
+                change -= 1
 
         return indexes, values
 

--- a/data/ant.py
+++ b/data/ant.py
@@ -192,12 +192,12 @@ class Ant(Thread):
         # Iterate probability list
         for index in range(len(indexes) - 1):
             # Check if two probabilities are almost equal
-            if not (random.random() < 0.2):
+            if random.random() >= 0.2:  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
                 continue
             if not (self.little_diference(values[index], values[index + 1]) and change < CHANGE_RATE):
                 continue
 
-            switch_probability = random.random()
+            switch_probability = random.random()  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
             # Check probability
             if switch_probability < SWITCH_PROBABILITY:
                 # Swap two probabilities

--- a/tests/test_ant.py
+++ b/tests/test_ant.py
@@ -1,0 +1,59 @@
+from data.ant import Ant
+
+
+def make_ant():
+    sequance = [0, 1, 1, 0]
+    pheronome = [[0.5, 0.5, 0.5] for _ in range(len(sequance) - 1)]
+    return Ant(0, sequance, pheronome, 5, 1)
+
+
+def test_selection_sort_orders_descending_by_value():
+    ant = make_ant()
+    indexes = [0, 1, 2, 3]
+    values = [3, 1, 4, 2]
+
+    sorted_indexes, sorted_values = ant.selection_sort(indexes, values)
+
+    assert sorted_values == [4, 3, 2, 1]
+    assert sorted_indexes == [2, 0, 3, 1]
+
+
+def test_randomize_equal_solutions_no_swap_when_probability_high(monkeypatch):
+    ant = make_ant()
+    monkeypatch.setattr("data.ant.random.random", lambda: 0.9)
+
+    indexes = [0, 1, 2]
+    values = [1.0, 1.0, 1.0]
+
+    result_indexes, result_values = ant.randomize_equal_solutions(indexes, values)
+
+    assert result_indexes == [0, 1, 2]
+    assert result_values == [1.0, 1.0, 1.0]
+
+
+def test_randomize_equal_solutions_swaps_when_change_rate_allows(monkeypatch, capsys):
+    ant = make_ant()
+    monkeypatch.setattr("data.ant.CHANGE_RATE", 1)
+    monkeypatch.setattr("data.ant.SWITCH_PROBABILITY", 1.0)
+    monkeypatch.setattr("data.ant.random.random", lambda: 0.0)
+
+    indexes = [0, 1, 2]
+    values = [1.0, 1.0001, 5.0]
+
+    result_indexes, result_values = ant.randomize_equal_solutions(indexes, values)
+
+    assert result_indexes == [1, 0, 2]
+    assert result_values == [1.0001, 1.0, 5.0]
+    assert "Swap" in capsys.readouterr().out
+
+
+def test_sort_by_combines_selection_sort_and_randomize(monkeypatch):
+    ant = make_ant()
+    monkeypatch.setattr("data.ant.random.random", lambda: 0.9)
+
+    indexes = [0, 1, 2]
+    values = [3, 1, 2]
+
+    result_indexes, result_values = ant.sort_by(indexes, values)
+
+    assert result_values == [3, 2, 1]


### PR DESCRIPTION
Reduces cognitive complexity from 17 to under the allowed threshold by separating the sorting pass from the tie-breaking randomization pass and flattening nested conditionals with early continues. Fixes SonarCloud python:S3776 at data/ant.py:162.

## Summary by Sourcery

Enhancements:
- Extract selection_sort and randomize_equal_solutions helpers from sort_by to separate concerns and simplify control flow.