### PR TITLE
Remove unused tabu_list parameter from update_tabu_list

### DIFF
--- a/gen_algo/ant_colony.py
+++ b/gen_algo/ant_colony.py
@@ -181,7 +181,7 @@ class AntColony:
 
         for mutated, original, tabu_list in zip(results, individuals, tabu_lists):
             if mutated != original and mutated != None:
-                tabu_lists[counter] = self.update_tabu_list(mutated, tabu_list)
+                tabu_lists[counter] = self.update_tabu_list(mutated)
 
             counter += 1
 
@@ -253,7 +253,7 @@ class AntColony:
 
         return deltas
 
-    def update_tabu_list(self, individual, tabu_list):
+    def update_tabu_list(self, individual):
         new_tabu_list = []
 
         vector = individual.get_individual()


### PR DESCRIPTION
The parameter was never read in the method body; the new tabu list is built entirely from the individual's vector configuration. Fixes SonarCloud python:S1172 at gen_algo/ant_colony.py:256.

## Summary by Sourcery

Enhancements:
- Streamline update_tabu_list by dropping an unused tabu_list parameter and updating callers accordingly.