### PR TITLE
Remove commented-out code in ant_colony.py

### DIFF
--- a/gen_algo/ant_colony.py
+++ b/gen_algo/ant_colony.py
@@ -127,8 +127,6 @@ class AntColony:
 
         return results
 
-    # return new_individuals
-
     def check_valid_of_new_individual(self, individual):
         if individual == None:
             return False
@@ -204,18 +202,10 @@ class AntColony:
         # print(i)
 
         for index_of_pheronome in range(1, len(self.pheronome)):
-            # new_pheronome = self.pheronome[index_of_pheronome]
-
             for index_of_pher in DIRECTIONS:
                 self.pheronome[index_of_pheronome][index_of_pher] *= EVAPORATE_CONSTANT
                 self.pheronome[index_of_pheronome][index_of_pher] += delta_pheronome[index_of_pheronome - 1][
                     index_of_pher]
-
-            # self.pheronome[index_of_pheronome][index_of_pher] = new_pheronome[index_of_pher]
-
-        # print(self.pheronome[index_of_pheronome], new_pheronome)
-        # self.pheronome[index_of_pheronome] = new_pheronome
-        # print("After: ",self.pheronome[index_of_pheronome], new_pheronome)
 
     def compute_delta_pheronome(self, individuals, tabu_lists):
         if self.verbose:
@@ -226,9 +216,6 @@ class AntColony:
             deltas = [0, 0, 0]
             for direction in DIRECTIONS:
                 for tabu_list, individual in zip(tabu_lists, individuals):
-                    # if index >= len(tabu_list):
-                    # 	tabu_list.append(STRAIGHT)
-
                     if tabu_list[index] == direction:
                         # deltas.append(DELTA_PHERONOME_CONSTANT/individual.get_free_energy() )
                         DELTA = DELTA_PHERONOME_CONSTANT / individual.get_free_energy()
@@ -244,12 +231,7 @@ class AntColony:
         return delta
 
     def add_to_delta_pheronome(self, deltas, direction, new_record):
-        # print(direction)
-        # print(len(deltas), direction)
-        # print("Delta before: ", deltas[direction])
-        # print(new_record)
         deltas[direction] += new_record
-        # print("Delta after: ", deltas[direction])
 
         return deltas
 


### PR DESCRIPTION
Fixes SonarCloud python:S125 at gen_algo/ant_colony.py:130,207,214,216,229,247.

## Summary by Sourcery

Chores:
- Clean up legacy commented-out code in ant_colony pheromone trail update and delta computation methods.