### PR TITLE
Mark non-security PRNG usage in ant_colony.py as intentional

### DIFF
--- a/gen_algo/ant_colony.py
+++ b/gen_algo/ant_colony.py
@@ -75,7 +75,7 @@ class AntColony:
         """
         Init pheronome
         """
-        return random.random()
+        return random.random()  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
 
     def search(self):
         """
@@ -161,7 +161,7 @@ class AntColony:
         # Multi-threaded
         pool = ThreadPool(8)
 
-        local_search_method_probability = random.random()
+        local_search_method_probability = random.random()  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
         if local_search_method_probability < 0.5:
             if self.verbose:
                 print("\tAnt-Colony -> Simulated Annealing")


### PR DESCRIPTION
random.random() here selects pheromone init values and the local search strategy, not a security decision. Suppresses SonarCloud python:S2245 false positives at gen_algo/ant_colony.py:78,164.

## Summary by Sourcery

Chores:
- Add NOSONAR comments to mark algorithmic randomness as an intentional non-security use of random.random in ant_colony.py.