### PR TITLE
Reduce cognitive complexity of generate_random and compute_free_energy

### DIFF
--- a/data/vector.py
+++ b/data/vector.py
@@ -211,11 +211,11 @@ class Vector:
         up_move = complex(0, -1)
         change_direction_probability = 0.7
 
-        if random.random() >= change_direction_probability:
+        if random.random() >= change_direction_probability:  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
             self.configuration[config] = right_move
             return "RIGHT"
 
-        if random.random() < 0.5:
+        if random.random() < 0.5:  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
             self.configuration[config] = up_move
             return "UP"
 
@@ -228,7 +228,7 @@ class Vector:
         up_move = complex(0, -1)
         change_direction_probability = 0.7
 
-        if random.random() < change_direction_probability:
+        if random.random() < change_direction_probability:  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
             self.configuration[config] = right_move
             return "RIGHT"
 

--- a/data/vector.py
+++ b/data/vector.py
@@ -14,6 +14,11 @@ HYDROPHOBILIC = 1
 NOT_VALID_CONFIGURATION = False
 VALID_CONFIGURATION = True
 
+RANDOM_WALK_RIGHT_MOVE = complex(1, 0)
+RANDOM_WALK_DOWN_MOVE = complex(0, 1)
+RANDOM_WALK_UP_MOVE = complex(0, -1)
+RANDOM_WALK_CHANGE_DIRECTION_PROBABILITY = 0.7
+
 
 class Vector:
     def __init__(self, protein_sequance):
@@ -206,33 +211,23 @@ class Vector:
         return self.pick_random_direction_from_side(config, state)
 
     def pick_random_direction_from_right(self, config):
-        right_move = complex(1, 0)
-        down_move = complex(0, 1)
-        up_move = complex(0, -1)
-        change_direction_probability = 0.7
-
-        if random.random() >= change_direction_probability:  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
-            self.configuration[config] = right_move
+        if random.random() >= RANDOM_WALK_CHANGE_DIRECTION_PROBABILITY:  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
+            self.configuration[config] = RANDOM_WALK_RIGHT_MOVE
             return "RIGHT"
 
         if random.random() < 0.5:  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
-            self.configuration[config] = up_move
+            self.configuration[config] = RANDOM_WALK_UP_MOVE
             return "UP"
 
-        self.configuration[config] = down_move
+        self.configuration[config] = RANDOM_WALK_DOWN_MOVE
         return "DOWN"
 
     def pick_random_direction_from_side(self, config, state):
-        right_move = complex(1, 0)
-        down_move = complex(0, 1)
-        up_move = complex(0, -1)
-        change_direction_probability = 0.7
-
-        if random.random() < change_direction_probability:  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
-            self.configuration[config] = right_move
+        if random.random() < RANDOM_WALK_CHANGE_DIRECTION_PROBABILITY:  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
+            self.configuration[config] = RANDOM_WALK_RIGHT_MOVE
             return "RIGHT"
 
-        self.configuration[config] = up_move if state == "UP" else down_move
+        self.configuration[config] = RANDOM_WALK_UP_MOVE if state == "UP" else RANDOM_WALK_DOWN_MOVE
         return state
 
     def save_config_to_file(self, filename):

--- a/data/vector.py
+++ b/data/vector.py
@@ -188,62 +188,52 @@ class Vector:
         """
         Generate random valid sequance
         """
-        for i in range(len(self.sequance) - 1):
+        for _ in range(len(self.sequance) - 1):
             self.configuration.append(complex(1, 0))
 
-        RIGHT = True
-        UP = False
-        DOWN = False
-
-        RIGHT_MOVE = complex(1, 0)
-        DOWN_MOVE = complex(0, 1)
-        UP_MOVE = complex(0, -1)
-
-        CHANGE_DIRECTION_PROBABILITY = 0.7
-
+        state = "RIGHT"
         for config in range(len(self.configuration)):
-            if RIGHT:
-                change_of_direction = random.random()
-                if change_of_direction < CHANGE_DIRECTION_PROBABILITY:
-                    direction = random.random()
-                    if direction < 0.5:
-                        self.configuration[config] = UP_MOVE
-                        RIGHT = False
-                        UP = True
-                    else:
-                        self.configuration[config] = DOWN_MOVE
-                        RIGHT = False
-                        DOWN = True
-                else:
-                    self.configuration[config] = RIGHT_MOVE
-                    RIGHT = True
-                    UP = False
-                    DOWN = False
+            state = self.pick_next_random_direction(config, state)
 
-            elif UP:
-                change_of_direction = random.random()
-                if change_of_direction < CHANGE_DIRECTION_PROBABILITY:
-                    self.configuration[config] = RIGHT_MOVE
-                    RIGHT = True
-                    UP = False
-                    DOWN = False
-                else:
-                    self.configuration[config] = UP_MOVE
-                    UP = True
-                    DOWN = False
-                    RIGHT = False
-            elif DOWN:
-                change_of_direction = random.random()
-                if change_of_direction < CHANGE_DIRECTION_PROBABILITY:
-                    self.configuration[config] = RIGHT_MOVE
-                    RIGHT = True
-                    DOWN = False
-                    UP = False
-                else:
-                    self.configuration[config] = DOWN_MOVE
-                    UP = False
-                    DOWN = True
-                    RIGHT = False
+    def pick_next_random_direction(self, config, state):
+        """
+        Pick next move of the random walk used to seed the configuration,
+        update self.configuration at config in place and return the new state
+        """
+        if state == "RIGHT":
+            return self.pick_random_direction_from_right(config)
+
+        return self.pick_random_direction_from_side(config, state)
+
+    def pick_random_direction_from_right(self, config):
+        right_move = complex(1, 0)
+        down_move = complex(0, 1)
+        up_move = complex(0, -1)
+        change_direction_probability = 0.7
+
+        if random.random() >= change_direction_probability:
+            self.configuration[config] = right_move
+            return "RIGHT"
+
+        if random.random() < 0.5:
+            self.configuration[config] = up_move
+            return "UP"
+
+        self.configuration[config] = down_move
+        return "DOWN"
+
+    def pick_random_direction_from_side(self, config, state):
+        right_move = complex(1, 0)
+        down_move = complex(0, 1)
+        up_move = complex(0, -1)
+        change_direction_probability = 0.7
+
+        if random.random() < change_direction_probability:
+            self.configuration[config] = right_move
+            return "RIGHT"
+
+        self.configuration[config] = up_move if state == "UP" else down_move
+        return state
 
     def save_config_to_file(self, filename):
         """
@@ -389,36 +379,43 @@ class Vector:
         """
         Compute free energy of configuration up to index
         """
-        free_energy = 0
-
         if space_config == None:
             space_conf = self.compute_space_configuration(index)
         else:
             space_conf = space_config
 
-        final_index_of_amino = None
         if index == None:
             final_index_of_amino = len(self.sequance) - 1
         else:
             final_index_of_amino = index + 1
 
-        # Iterate all amino
-        for first in range(0, final_index_of_amino):
-            # Check if amino is hydropohoboli ( free energy is depedent on it )
-            if self.sequance[first] == HYDROPHOBILIC:
-                # Iterate amino to end of protein
-                for second in range(first + 1, final_index_of_amino + 1):
-                    # Check if amino is hydropohoboli ( free energy is depedent on it )
-                    if self.sequance[second] == HYDROPHOBILIC:
-                        # Add to free energy ( absolute value of two complex numbers)
-                        energy = self.length_between_amino(space_conf[first], space_conf[second])
+        free_energy = self.sum_hydrophobic_pair_distances(space_conf, final_index_of_amino)
 
-                        free_energy += energy
         if self.verbose:
             print("Free energy: ", free_energy)
 
         if free_energy == 0:
             return 1
+
+        return free_energy
+
+    def sum_hydrophobic_pair_distances(self, space_conf, final_index_of_amino):
+        """
+        Sum distances between every pair of hydrophobic amino acids up to final_index_of_amino
+        """
+        free_energy = 0
+
+        # Iterate all amino
+        for first in range(0, final_index_of_amino):
+            # Check if amino is hydropohoboli ( free energy is depedent on it )
+            if self.sequance[first] != HYDROPHOBILIC:
+                continue
+            # Iterate amino to end of protein
+            for second in range(first + 1, final_index_of_amino + 1):
+                # Check if amino is hydropohoboli ( free energy is depedent on it )
+                if self.sequance[second] == HYDROPHOBILIC:
+                    # Add to free energy ( absolute value of two complex numbers)
+                    free_energy += self.length_between_amino(space_conf[first], space_conf[second])
 
         return free_energy
 


### PR DESCRIPTION
- generate_random: replace the boolean-flag RIGHT/UP/DOWN state machine with a string state and per-state helper methods, preserving the exact same random-call sequence and transition probabilities.
- compute_free_energy: extract the nested hydrophobic-pair distance sum into sum_hydrophobic_pair_distances and flatten with an early continue.

Fixes SonarCloud python:S3776 at data/vector.py:187,388.

## Summary by Sourcery

Refactor random configuration generation and free energy computation to reduce cognitive complexity while preserving existing behavior.

Enhancements:
- Simplify generate_random by introducing state-based helper methods for choosing random walk directions.
- Extract hydrophobic pair distance accumulation into sum_hydrophobic_pair_distances and streamline compute_free_energy logic.