### PR TITLE
Remove unreachable verbose print in AntColony.__init__

### DIFF
--- a/gen_algo/ant_colony.py
+++ b/gen_algo/ant_colony.py
@@ -35,9 +35,6 @@ class AntColony:
     def __init__(self, count_of_ants, sequance, iteration, max_iteration):
         self.verbose = False
 
-        if self.verbose:
-            print("\tAnt Colony -> Init")
-
         self.COUNT_OF_ANTS = count_of_ants
         self.ants = []
         self.sequance = sequance


### PR DESCRIPTION
self.verbose is set to False immediately above with nothing in between to change it, so the guarded print could never execute. Fixes SonarCloud pythonbugs:S2583 at gen_algo/ant_colony.py:38.

## Summary by Sourcery

Bug Fixes:
- Eliminate a logically unreachable print guarded by a verbose flag that is always False.