### PR TITLE
Extract duplicated log-prefix string literals to constants

### DIFF
--- a/data/vector.py
+++ b/data/vector.py
@@ -14,6 +14,9 @@ HYDROPHOBILIC = 1
 NOT_VALID_CONFIGURATION = False
 VALID_CONFIGURATION = True
 
+SPACE_CONFIGURATION_LOG_PREFIX = "Space configuration: "
+FREE_ENERGY_LOG_PREFIX = "Free energy: "
+
 
 class Vector:
     def __init__(self, protein_sequance):
@@ -62,7 +65,7 @@ class Vector:
 
     def check_space_configuration_counter(self, direction, index):
         self.space_configuration = self.compute_space_configuration_to_index(index)
-        print("Space configuration: ", self.space_configuration)
+        print(SPACE_CONFIGURATION_LOG_PREFIX, self.space_configuration)
 
         new_space_config = self.space_configuration[-1] + direction
         self.space_configuration_counter = Counter(self.space_configuration)
@@ -379,7 +382,7 @@ class Vector:
             self.space_configuration.append(sum_of_space_config)
 
         if self.verbose:
-            print("Space configuration: ", self.space_configuration)
+            print(SPACE_CONFIGURATION_LOG_PREFIX, self.space_configuration)
 
         self.space_configuration_counter = Counter(self.space_configuration)
 
@@ -415,7 +418,7 @@ class Vector:
 
                         free_energy += energy
         if self.verbose:
-            print("Free energy: ", free_energy)
+            print(FREE_ENERGY_LOG_PREFIX, free_energy)
 
         if free_energy == 0:
             return 1
@@ -448,8 +451,8 @@ if __name__ == "__main__":
     print(vector)
     space_config = vector.compute_space_configuration(0)
     free_energy = vector.compute_free_energy(0)
-    print("Space configuration: ", space_config)
-    print("Free energy: ", free_energy, " ( 1 )")
+    print(SPACE_CONFIGURATION_LOG_PREFIX, space_config)
+    print(FREE_ENERGY_LOG_PREFIX, free_energy, " ( 1 )")
     vector.plot_config(0)
 
     print("Param: ", vector.compute_space_configuration(3))
@@ -481,8 +484,8 @@ if __name__ == "__main__":
                     min_index = counter
                     min_of_free_energy = free_energy
 
-            print("Space configuration: ", space_config)
-            print("Free energy: ", free_energy)
+            print(SPACE_CONFIGURATION_LOG_PREFIX, space_config)
+            print(FREE_ENERGY_LOG_PREFIX, free_energy)
             print("Validity: ", not invalid)
 
             vector.plot_config(index_of_config)
@@ -498,8 +501,8 @@ if __name__ == "__main__":
         vector.plot_config(index_of_config)
         print(" ============ ")
 
-    print("Space configuration: ", vector.compute_space_configuration())
+    print(SPACE_CONFIGURATION_LOG_PREFIX, vector.compute_space_configuration())
 
-    print("Free energy: ", vector.compute_free_energy())
+    print(FREE_ENERGY_LOG_PREFIX, vector.compute_free_energy())
     print(vector)
     vector.plot_config()


### PR DESCRIPTION
Fixes SonarCloud python:S1192 at data/vector.py:65,418.

## Summary by Sourcery

Enhancements:
- Introduce constants for space configuration and free energy log prefixes to remove duplicated string literals and improve maintainability.