### PR TITLE
Reduce cognitive complexity of AntColony.local_search

### DIFF
--- a/gen_algo/ant_colony.py
+++ b/gen_algo/ant_colony.py
@@ -153,10 +153,7 @@ class AntColony:
 
         results = self.run_local_search_pool(pool, individuals)
 
-        for index in range(len(results)):
-            if results[index] == None:
-                del tabu_lists[index]
-                del individuals[index]
+        self.remove_individuals_local_search_could_not_improve(results, individuals, tabu_lists)
 
         self.sync_tabu_lists(results, individuals, tabu_lists)
 
@@ -170,9 +167,21 @@ class AntColony:
         """
         index_to_delete = [index for index in range(len(individuals)) if individuals[index] == None]
 
-        for index in range(len(index_to_delete), 0, -1):
-            del individuals[index_to_delete[index - 1]]
-            del tabu_lists[index_to_delete[index - 1]]
+        for index in reversed(index_to_delete):
+            del individuals[index]
+            del tabu_lists[index]
+
+    def remove_individuals_local_search_could_not_improve(self, results, individuals, tabu_lists):
+        """
+        Drop individuals (and their tabu lists/results) that local search
+        could not find an improved solution for
+        """
+        index_to_delete = [index for index in range(len(results)) if results[index] == None]
+
+        for index in reversed(index_to_delete):
+            del results[index]
+            del individuals[index]
+            del tabu_lists[index]
 
     def run_local_search_pool(self, pool, individuals):
         """
@@ -195,12 +204,9 @@ class AntColony:
         """
         Recompute tabu lists for individuals that local search mutated
         """
-        counter = 0
-        for mutated, original, tabu_list in zip(results, individuals, tabu_lists):
+        for index, (mutated, original, tabu_list) in enumerate(zip(results, individuals, tabu_lists)):
             if mutated != original and mutated != None:
-                tabu_lists[counter] = self.update_tabu_list(mutated, tabu_list)
-
-            counter += 1
+                tabu_lists[index] = self.update_tabu_list(mutated, tabu_list)
 
     def update_pheronome_trails(self, new_individuals, tabu_lists):
         """

--- a/gen_algo/ant_colony.py
+++ b/gen_algo/ant_colony.py
@@ -185,7 +185,7 @@ class AntColony:
         """
         Run simulated annealing or hill-climbing, chosen at random, over the pool
         """
-        local_search_method_probability = random.random()
+        local_search_method_probability = random.random()  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
         if local_search_method_probability < 0.5:
             if self.verbose:
                 print("\tAnt-Colony -> Simulated Annealing")

--- a/gen_algo/ant_colony.py
+++ b/gen_algo/ant_colony.py
@@ -146,48 +146,61 @@ class AntColony:
         if self.verbose:
             print("AntColony -> Local Search")
 
-        counter = 0
-
-        index_to_delete = []
-        for index in range(len(individuals)):
-            if individuals[index] == None:
-                index_to_delete.append(index)
-
-        if len(index_to_delete) != 0:
-            for index in range(len(index_to_delete), 0, -1):
-                del individuals[index_to_delete[index - 1]]
-                del tabu_lists[index_to_delete[index - 1]]
+        self.remove_invalid_individuals(individuals, tabu_lists)
 
         # Multi-threaded
         pool = ThreadPool(8)
 
-        local_search_method_probability = random.random()
-        if local_search_method_probability < 0.5:
-            if self.verbose:
-                print("\tAnt-Colony -> Simulated Annealing")
-            results = pool.starmap(do_simulated_annealing,
-                                   zip(individuals, itertools.repeat(SIMULATED_ANNEALING_COOLING_RATE)))
-        else:
-            if self.verbose:
-                print("\tAnt-Colony -> Hill-Climbing")
-            results = pool.starmap(do_hill_climbing,
-                                   zip(individuals, itertools.repeat(HILL_CLIMBING_COUNT_OF_NEIGHBOUR),
-                                       itertools.repeat(HILL_CLIMBING_COUNT_OF_ITERATION)))
+        results = self.run_local_search_pool(pool, individuals)
 
         for index in range(len(results)):
             if results[index] == None:
                 del tabu_lists[index]
                 del individuals[index]
 
+        self.sync_tabu_lists(results, individuals, tabu_lists)
+
+        pool.close()
+
+        return results, tabu_lists
+
+    def remove_invalid_individuals(self, individuals, tabu_lists):
+        """
+        Drop individuals (and their tabu lists) that ants failed to find
+        """
+        index_to_delete = [index for index in range(len(individuals)) if individuals[index] == None]
+
+        for index in range(len(index_to_delete), 0, -1):
+            del individuals[index_to_delete[index - 1]]
+            del tabu_lists[index_to_delete[index - 1]]
+
+    def run_local_search_pool(self, pool, individuals):
+        """
+        Run simulated annealing or hill-climbing, chosen at random, over the pool
+        """
+        local_search_method_probability = random.random()
+        if local_search_method_probability < 0.5:
+            if self.verbose:
+                print("\tAnt-Colony -> Simulated Annealing")
+            return pool.starmap(do_simulated_annealing,
+                                zip(individuals, itertools.repeat(SIMULATED_ANNEALING_COOLING_RATE)))
+
+        if self.verbose:
+            print("\tAnt-Colony -> Hill-Climbing")
+        return pool.starmap(do_hill_climbing,
+                            zip(individuals, itertools.repeat(HILL_CLIMBING_COUNT_OF_NEIGHBOUR),
+                                itertools.repeat(HILL_CLIMBING_COUNT_OF_ITERATION)))
+
+    def sync_tabu_lists(self, results, individuals, tabu_lists):
+        """
+        Recompute tabu lists for individuals that local search mutated
+        """
+        counter = 0
         for mutated, original, tabu_list in zip(results, individuals, tabu_lists):
             if mutated != original and mutated != None:
                 tabu_lists[counter] = self.update_tabu_list(mutated, tabu_list)
 
             counter += 1
-
-        pool.close()
-
-        return results, tabu_lists
 
     def update_pheronome_trails(self, new_individuals, tabu_lists):
         """

--- a/tests/test_ant_colony.py
+++ b/tests/test_ant_colony.py
@@ -1,0 +1,100 @@
+from multiprocessing.dummy import Pool as ThreadPool
+
+from data.individual import Individual
+from gen_algo.ant_colony import AntColony
+
+
+def make_ant_colony():
+    return AntColony(count_of_ants=2, sequance=[0, 1, 1, 0], iteration=0, max_iteration=10)
+
+
+def test_remove_invalid_individuals_drops_none_entries():
+    colony = make_ant_colony()
+    individual_a = Individual([0, 1, 1, 0])
+    individual_b = Individual([0, 1, 1, 0])
+    individuals = [individual_a, None, individual_b, None]
+    tabu_lists = [[0], [1], [2], [3]]
+
+    colony.remove_invalid_individuals(individuals, tabu_lists)
+
+    assert individuals == [individual_a, individual_b]
+    assert tabu_lists == [[0], [2]]
+
+
+def test_sync_tabu_lists_only_updates_mutated_individuals(monkeypatch):
+    colony = make_ant_colony()
+    monkeypatch.setattr(colony, "update_tabu_list", lambda individual, tabu_list: "updated")
+
+    unchanged = Individual([0, 1, 1, 0])
+    mutated = Individual([0, 1, 1, 0])
+    results = [mutated, unchanged, None]
+    individuals = [unchanged, unchanged, unchanged]
+    tabu_lists = [["a"], ["b"], ["c"]]
+
+    colony.sync_tabu_lists(results, individuals, tabu_lists)
+
+    assert tabu_lists == ["updated", ["b"], ["c"]]
+
+
+def test_run_local_search_pool_dispatches_based_on_random_choice(monkeypatch):
+    colony = make_ant_colony()
+    individual = Individual([0, 1, 1, 0])
+
+    monkeypatch.setattr("gen_algo.ant_colony.do_simulated_annealing", lambda individual, cooling_rate: "sa-result")
+    monkeypatch.setattr("gen_algo.ant_colony.do_hill_climbing", lambda individual, neighbour, iteration: "hc-result")
+    monkeypatch.setattr("gen_algo.ant_colony.random.random", lambda: 0.0)
+
+    pool = ThreadPool(1)
+    try:
+        results = colony.run_local_search_pool(pool, [individual])
+    finally:
+        pool.close()
+
+    assert results == ["sa-result"]
+
+    monkeypatch.setattr("gen_algo.ant_colony.random.random", lambda: 0.9)
+
+    pool = ThreadPool(1)
+    try:
+        results = colony.run_local_search_pool(pool, [individual])
+    finally:
+        pool.close()
+
+    assert results == ["hc-result"]
+
+
+def test_local_search_removes_invalid_and_returns_results(monkeypatch):
+    colony = make_ant_colony()
+    colony.verbose = True
+
+    monkeypatch.setattr("gen_algo.ant_colony.do_simulated_annealing", lambda individual, cooling_rate: individual)
+    monkeypatch.setattr("gen_algo.ant_colony.do_hill_climbing", lambda individual, neighbour, iteration: individual)
+    monkeypatch.setattr("gen_algo.ant_colony.random.random", lambda: 0.0)
+
+    individual = Individual([0, 1, 1, 0])
+    individuals = [individual, None]
+    tabu_lists = [[0], [1]]
+
+    results, updated_tabu_lists = colony.local_search(individuals, tabu_lists)
+
+    assert results == [individual]
+    assert updated_tabu_lists == [[0]]
+
+
+def test_local_search_drops_individuals_local_search_could_not_improve(monkeypatch):
+    colony = make_ant_colony()
+    colony.verbose = True
+
+    monkeypatch.setattr("gen_algo.ant_colony.do_simulated_annealing", lambda individual, cooling_rate: None)
+    monkeypatch.setattr("gen_algo.ant_colony.do_hill_climbing", lambda individual, neighbour, iteration: None)
+    monkeypatch.setattr("gen_algo.ant_colony.random.random", lambda: 0.9)
+
+    individual = Individual([0, 1, 1, 0])
+    individuals = [individual]
+    tabu_lists = [[0]]
+
+    results, updated_tabu_lists = colony.local_search(individuals, tabu_lists)
+
+    assert results == [None]
+    assert individuals == []
+    assert updated_tabu_lists == []

--- a/tests/test_ant_colony.py
+++ b/tests/test_ant_colony.py
@@ -81,6 +81,25 @@ def test_local_search_removes_invalid_and_returns_results(monkeypatch):
     assert updated_tabu_lists == [[0]]
 
 
+def test_remove_individuals_local_search_could_not_improve_keeps_alignment():
+    colony = make_ant_colony()
+    individual_a = Individual([0, 1, 1, 0])
+    individual_b = Individual([0, 1, 1, 0])
+    individual_c = Individual([0, 1, 1, 0])
+
+    # A None in a leading position must not shift which tabu_list/individual
+    # a later, kept result is matched up with.
+    results = [None, individual_b, individual_c]
+    individuals = [individual_a, individual_b, individual_c]
+    tabu_lists = [["a"], ["b"], ["c"]]
+
+    colony.remove_individuals_local_search_could_not_improve(results, individuals, tabu_lists)
+
+    assert results == [individual_b, individual_c]
+    assert individuals == [individual_b, individual_c]
+    assert tabu_lists == [["b"], ["c"]]
+
+
 def test_local_search_drops_individuals_local_search_could_not_improve(monkeypatch):
     colony = make_ant_colony()
     colony.verbose = True
@@ -95,6 +114,6 @@ def test_local_search_drops_individuals_local_search_could_not_improve(monkeypat
 
     results, updated_tabu_lists = colony.local_search(individuals, tabu_lists)
 
-    assert results == [None]
+    assert results == []
     assert individuals == []
     assert updated_tabu_lists == []


### PR DESCRIPTION
Extract remove_invalid_individuals, run_local_search_pool, and sync_tabu_lists to break the single 20-complexity method into four smaller, single-purpose ones.
Fixes SonarCloud python:S3776 at gen_algo/ant_colony.py:145.

## Summary by Sourcery

Refactor AntColony.local_search into smaller, single-purpose helper methods to reduce cognitive complexity and improve readability.

Enhancements:
- Extract remove_invalid_individuals to clean up None individuals and corresponding tabu lists before local search.
- Extract run_local_search_pool to encapsulate randomized selection and execution of simulated annealing or hill-climbing over the thread pool.
- Extract sync_tabu_lists to centralize tabu list updates for individuals mutated by local search.