### PR TITLE
Replace wildcard collections import with explicit Counter import

### DIFF
--- a/data/vector.py
+++ b/data/vector.py
@@ -1,7 +1,7 @@
 #! /usr/bin/python3
 
 import random
-from collections import *
+from collections import Counter
 from copy import deepcopy
 
 import matplotlib


### PR DESCRIPTION
Fixes SonarCloud python:S2208 at data/vector.py:4.

## Summary by Sourcery

Enhancements:
- Limit collections import to Counter instead of using a wildcard import for clearer and safer dependencies.