### PR TITLE
Rename do_crossover parameter CROSSOVER_RATE to crossover_rate

### DIFF
--- a/gen_algo/crossover.py
+++ b/gen_algo/crossover.py
@@ -4,7 +4,7 @@ import random
 from copy import deepcopy
 
 
-def do_crossover(first_individual, second_individual, crossover_rate=0.3):
+def do_crossover(first_individual, second_individual):
     # Crossover two individual
     crossover_mode_probability = random.random()
 

--- a/gen_algo/crossover.py
+++ b/gen_algo/crossover.py
@@ -4,7 +4,7 @@ import random
 from copy import deepcopy
 
 
-def do_crossover(first_individual, second_individual, CROSSOVER_RATE=0.3):
+def do_crossover(first_individual, second_individual, crossover_rate=0.3):
     # Crossover two individual
     crossover_mode_probability = random.random()
 

--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -265,7 +265,7 @@ class GeneticsAlgorithm(AbstractSolver):
             first_individual, first_index = population.pick_random_individual()
             second_individual, second_index = population.pick_random_individual()
 
-            crossover_individuals = do_crossover(first_individual, second_individual, self.CROSSOVER_RATE)
+            crossover_individuals = do_crossover(first_individual, second_individual)
 
             if crossover_individuals[0] != first_individual:
                 population.set_individual_at(first_index, crossover_individuals[0])


### PR DESCRIPTION
Fixes SonarCloud python:S117 at gen_algo/crossover.py:7.

## Summary by Sourcery

Enhancements:
- Standardize the do_crossover crossover rate parameter name to lowercase snake_case (crossover_rate) for consistency and style compliance.