### PR TITLE
Mark non-security PRNG usage in Ant.sort_by as intentional

### DIFF
--- a/data/ant.py
+++ b/data/ant.py
@@ -179,9 +179,9 @@ class Ant(Thread):
         # Iterate probability list
         for index in range(len(indexes) - 1):
             # Check if two probabilities are almost equal
-            if random.random() < 0.2:
+            if random.random() < 0.2:  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
                 if self.little_diference(values[index], values[index + 1]) and change < CHANGE_RATE:
-                    switch_probability = random.random()
+                    switch_probability = random.random()  # NOSONAR python:S2245 - non-cryptographic use, algorithmic randomness only
                     # Check probability
                     if switch_probability < SWITCH_PROBABILITY:
                         # Swap two probabilities


### PR DESCRIPTION
random.random() here drives algorithmic tie-breaking in the ant colony search, not a security decision. Suppresses SonarCloud python:S2245 false positive at data/ant.py:182,184.

## Summary by Sourcery

Enhancements:
- Mark ant colony sort tie-breaking randomness as intentional non-cryptographic usage to silence SonarCloud S2245 false positives.