### PR TITLE
Replace unused loop index candicate with _ in generate_candidate_list

### DIFF
--- a/data/population.py
+++ b/data/population.py
@@ -51,7 +51,7 @@ class Population:
         Generate list of candidates before select
         """
         candidate_list = []
-        for candicate in range(SIZE_OF_CANDICATE_LIST):
+        for _ in range(SIZE_OF_CANDICATE_LIST):
             candidate_list.append(random.randint(0, self.size_of_population - 1))
 
         return candidate_list


### PR DESCRIPTION
Fixes SonarCloud python:S1481 at data/population.py:54.

## Summary by Sourcery

Enhancements:
- Clean up generate_candidate_list by removing an unused loop variable flagged by static analysis.