### PR TITLE
Remove unused local variable MAX_SIZE_OF_CONFIG in Ant.search

### DIFF
--- a/data/ant.py
+++ b/data/ant.py
@@ -67,8 +67,6 @@ class Ant(Thread):
         self.tabu_list.append(0)
         # print(self.vector)
 
-        MAX_SIZE_OF_CONFIG = len(self.vector.get_amino_sequance()) - 1
-
         self.create_configuration(1, pheronome)
 
         # Check if new individuals was found


### PR DESCRIPTION
Fixes SonarCloud python:S1481 at data/ant.py:70.

## Summary by Sourcery

Enhancements:
- Clean up Ant.search by eliminating an unnecessary configuration size variable.