### PR TITLE
Replace wildcard threading import with explicit Thread import

### DIFF
--- a/data/ant.py
+++ b/data/ant.py
@@ -2,7 +2,7 @@
 
 import math
 import random
-from threading import *
+from threading import Thread
 
 import utils
 from data.individual import Individual


### PR DESCRIPTION
Fixes SonarCloud python:S2208 at data/ant.py:5.

## Summary by Sourcery

Replace wildcard threading import with an explicit Thread import in data/ant.py to satisfy static analysis requirements.

Bug Fixes:
- Resolve SonarCloud rule python:S2208 warning by avoiding wildcard import from threading.

Enhancements:
- Use explicit Thread import instead of wildcard threading import to improve code clarity and maintainability.