### PR TITLE
Remove unused CROSSOVER_RATE parameter from do_crossover

### DIFF
--- a/gen_algo/crossover.py
+++ b/gen_algo/crossover.py
@@ -4,7 +4,7 @@ import random
 from copy import deepcopy
 
 
-def do_crossover(first_individual, second_individual, CROSSOVER_RATE=0.3):
+def do_crossover(first_individual, second_individual):
     # Crossover two individual
     crossover_mode_probability = random.random()
 

--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -265,7 +265,7 @@ class GeneticsAlgorithm(AbstractSolver):
             first_individual, first_index = population.pick_random_individual()
             second_individual, second_index = population.pick_random_individual()
 
-            crossover_individuals = do_crossover(first_individual, second_individual, self.CROSSOVER_RATE)
+            crossover_individuals = do_crossover(first_individual, second_individual)
 
             if crossover_individuals[0] != first_individual:
                 population.set_individual_at(first_index, crossover_individuals[0])


### PR DESCRIPTION
The parameter was never read; crossover mode is chosen internally via random.random(). Updates the one caller in genetics_algorithm.py to match.
Fixes SonarCloud python:S1172 at gen_algo/crossover.py:7.

## Summary by Sourcery

Enhancements:
- Simplify the crossover API by removing an unused CROSSOVER_RATE argument from do_crossover and its call site.