### PR TITLE
Rename constructor parameter STORE_INDIVIDUALS_PER_GENERATION to stor…

### DIFF
--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -40,7 +40,7 @@ COUNT_OF_ANTS = 8
 class GeneticsAlgorithm(AbstractSolver):
     def __init__(self, sequance, MAX_GENERATION, POPULATION_SIZE,
                  COUNT_OF_MUTATION_PER_GENERATION, COUNT_OF_CROSSOVER_PER_GENERATION,
-                 MUTATE_RATE, CROSSOVER_RATE, STORE_INDIVIDUALS_PER_GENERATION=True):
+                 MUTATE_RATE, CROSSOVER_RATE, store_individuals_per_generation=True):
 
         self.MAX_GENERATION = MAX_GENERATION
         self.POPULATION_SIZE = POPULATION_SIZE
@@ -55,7 +55,7 @@ class GeneticsAlgorithm(AbstractSolver):
         self.COUNT_OF_MUTATION_PER_GENERATION = COUNT_OF_MUTATION_PER_GENERATION
         self.COUNT_OF_CROSSOVER_PER_GENERATION = COUNT_OF_CROSSOVER_PER_GENERATION
 
-        self.STORE_INDIVIDUALS_PER_GENERATION = STORE_INDIVIDUALS_PER_GENERATION
+        self.STORE_INDIVIDUALS_PER_GENERATION = store_individuals_per_generation
         self.list_individuals = []
 
         super().__init__(sequance)

--- a/tests/test_genetics_algorithm.py
+++ b/tests/test_genetics_algorithm.py
@@ -69,7 +69,7 @@ def test_solve_stores_individuals_by_default(monkeypatch):
 def test_solve_does_not_store_individuals_when_disabled(monkeypatch):
     solver = make_solver(
         3, population_size=4, monkeypatch=monkeypatch,
-        STORE_INDIVIDUALS_PER_GENERATION=False,
+        store_individuals_per_generation=False,
     )
 
     solver.solve()
@@ -80,7 +80,7 @@ def test_solve_does_not_store_individuals_when_disabled(monkeypatch):
 def test_solve_stores_individuals_when_explicitly_enabled(monkeypatch):
     solver = make_solver(
         3, population_size=4, monkeypatch=monkeypatch,
-        STORE_INDIVIDUALS_PER_GENERATION=True,
+        store_individuals_per_generation=True,
     )
 
     solver.solve()


### PR DESCRIPTION
…e_individuals_per_generation

Updates the two test call sites that pass it by keyword. Fixes SonarCloud python:S117 at gen_algo/genetics_algorithm.py:43.

## Summary by Sourcery

Rename a genetics algorithm constructor parameter to follow naming conventions and update corresponding test usages.

Enhancements:
- Rename the STORE_INDIVIDUALS_PER_GENERATION constructor parameter to store_individuals_per_generation in GeneticsAlgorithm to satisfy naming rules.

Tests:
- Update genetics algorithm tests to use the new store_individuals_per_generation keyword argument name.