### PR TITLE
Rename do_hill_climbing parameters to lowercase

### DIFF
--- a/gen_algo/hill_climbing.py
+++ b/gen_algo/hill_climbing.py
@@ -8,14 +8,14 @@ COUNT_OF_ITERATION = 10
 COUNT_OF_NEIGHBOR = 12
 
 
-def do_hill_climbing(individual, COUNT_OF_ITERATION=5, COUNT_OF_NEIGHBOR=6):
+def do_hill_climbing(individual, count_of_iteration=5, count_of_neighbor=6):
     """
     Main method for hill-climbing
     """
     # if verbose:
     # 	print ( "Hill climbing")
 
-    new_individual = hill_climbing(individual, COUNT_OF_ITERATION, COUNT_OF_NEIGHBOR)
+    new_individual = hill_climbing(individual, count_of_iteration, count_of_neighbor)
 
     return new_individual
 


### PR DESCRIPTION
Fixes SonarCloud python:S117 at gen_algo/hill_climbing.py:11.

## Summary by Sourcery

Enhancements:
- Align hill climbing helper function parameter names with lowercase naming conventions.