### PR TITLE
Remove commented-out code in do_hill_climbing

### DIFF
--- a/gen_algo/hill_climbing.py
+++ b/gen_algo/hill_climbing.py
@@ -12,9 +12,6 @@ def do_hill_climbing(individual, COUNT_OF_ITERATION=5, COUNT_OF_NEIGHBOR=6):
     """
     Main method for hill-climbing
     """
-    # if verbose:
-    # 	print ( "Hill climbing")
-
     new_individual = hill_climbing(individual, COUNT_OF_ITERATION, COUNT_OF_NEIGHBOR)
 
     return new_individual


### PR DESCRIPTION
Fixes SonarCloud python:S125 at gen_algo/hill_climbing.py:15.

## Summary by Sourcery

Chores:
- Clean up commented-out debug printing in do_hill_climbing to satisfy static analysis.