### PR TITLE
Replace unused loop index i with _ in hill_climbing

### DIFF
--- a/gen_algo/hill_climbing.py
+++ b/gen_algo/hill_climbing.py
@@ -29,7 +29,7 @@ def hill_climbing(individual, iteration, count_of_neighour):
     init_score = individual.get_free_energy()
     best_score = init_score
 
-    for i in range(count_of_neighour):
+    for _ in range(count_of_neighour):
         indi = do_mutation(individual)
         score = indi.compute_free_energy()
 


### PR DESCRIPTION
Fixes SonarCloud python:S1481 at gen_algo/hill_climbing.py:32.

## Summary by Sourcery

Enhancements:
- Clean up hill_climbing loop by replacing an unused index variable with a placeholder identifier.