### PR TITLE
Remove commented-out code in mutation.py

### DIFF
--- a/gen_algo/mutation.py
+++ b/gen_algo/mutation.py
@@ -42,9 +42,6 @@ def mutate_one_point(individual, MUTATION_RATE):
 
     return mutated individual
     """
-    # if verbose:
-    # 	print ( "GeneticsAlgorithm -> mutate_one_point")
-
     mutate_individual = deepcopy(individual)
     mutate_vector = mutate_individual.get_individual()
     mutate_config = mutate_vector.get_configuration()
@@ -67,9 +64,6 @@ def mutate_from_point(individual, MUTATION_RATE):
 
     return mutated individual
     """
-    # if verbose:
-    # 	print ( "GeneticsAlgorithm -> mutate_from_point")
-
     mutate_individual = deepcopy(individual)
     mutate_vector = mutate_individual.get_individual()
     mutate_config = mutate_vector.get_configuration()
@@ -91,9 +85,6 @@ def mutate_from_to_point(individual, MUTATION_RATE):
 
     return mutated individual
     """
-    # if verbose:
-    # 	print ( "GeneticsAlgorithm -> mutate_from_to_point")
-
     mutate_individual = deepcopy(individual)
     mutate_vector = mutate_individual.get_individual()
     mutate_config = mutate_vector.get_configuration()


### PR DESCRIPTION
Fixes SonarCloud python:S125 at gen_algo/mutation.py:45,70,94.

## Summary by Sourcery

Chores:
- Clean up commented-out code in mutation.py reported by SonarCloud as dead/commented code.