### PR TITLE
Remove unused path_to_file parameter from read_history_of_configurati…

### DIFF
--- a/visualize_protein_history.py
+++ b/visualize_protein_history.py
@@ -28,7 +28,7 @@ def visualize(history, counter):
         counter_of_diagrams += 1
 
 
-def read_history_of_configuration_of(path_to_file):
+def read_history_of_configuration_of():
     all_configuration_history_of_protein = []
     all_configuration_history_of_protein = utils.read_configuration_history(full_name_to_file, protein.get_sequance())
 
@@ -45,7 +45,7 @@ if __name__ == "__main__":
         full_name_to_file = utils.create_filename(number_of_file)
         full_name_to_file = os.path.join(RESULT_FOLDER, full_name_to_file)
 
-        history_of_configuration = read_history_of_configuration_of(full_name_to_file)
+        history_of_configuration = read_history_of_configuration_of()
         history.append(history_of_configuration)
 
     counter = 2

--- a/visualize_protein_history.py
+++ b/visualize_protein_history.py
@@ -28,9 +28,9 @@ def visualize(history, counter):
         counter_of_diagrams += 1
 
 
-def read_history_of_configuration_of():
+def read_history_of_configuration_of(path_to_file):
     all_configuration_history_of_protein = []
-    all_configuration_history_of_protein = utils.read_configuration_history(full_name_to_file, protein.get_sequance())
+    all_configuration_history_of_protein = utils.read_configuration_history(path_to_file, protein.get_sequance())
 
     return all_configuration_history_of_protein
 
@@ -45,7 +45,7 @@ if __name__ == "__main__":
         full_name_to_file = utils.create_filename(number_of_file)
         full_name_to_file = os.path.join(RESULT_FOLDER, full_name_to_file)
 
-        history_of_configuration = read_history_of_configuration_of()
+        history_of_configuration = read_history_of_configuration_of(full_name_to_file)
         history.append(history_of_configuration)
 
     counter = 2


### PR DESCRIPTION
…on_of

The function reads full_name_to_file/protein from the enclosing module scope rather than its argument, so the parameter was dead. Fixes SonarCloud python:S1172 at visualize_protein_history.py:31.

## Summary by Sourcery

Remove an unused path_to_file parameter from the configuration history reader and update its call site accordingly to rely on module-scope variables.