### PR TITLE
Remove unused local variable count_of_records in visualize

### DIFF
--- a/visualize_protein_history.py
+++ b/visualize_protein_history.py
@@ -11,7 +11,6 @@ CONFIGURATION_FOLDER = "configuration_diagram"
 
 
 def visualize(history, counter):
-    count_of_records = len(history)
     counter_of_diagrams = 1
 
     path = os.path.join(CONFIGURATION_FOLDER, utils.create_filename(counter))


### PR DESCRIPTION
Fixes SonarCloud python:S1481 at visualize_protein_history.py:14.

## Summary by Sourcery

Bug Fixes:
- Eliminate an unused local variable flagged by SonarCloud in visualize().