### PR TITLE
Pin pip version in the Install dependencies step

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,8 +33,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        # Constrained (not exact-pinned) so patch releases still apply automatically.
-        python -m pip install --upgrade "pip~=25.2"
+        # Exact-pinned (not a range) since SonarCloud's dependency-locking rule
+        # requires a single resolved version, not a compatible-release range.
+        python -m pip install --upgrade pip==25.2
         python -m pip install flake8==7.3.0 pytest==9.1.1
         # --only-binary=:all: is intentionally not used here: some of requirements.txt's
         # pins (e.g. matplotlib==3.9.0) have no wheel for every Python version in this

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,8 +33,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip==25.2
+        # Constrained (not exact-pinned) so patch releases still apply automatically.
+        python -m pip install --upgrade "pip~=25.2"
         python -m pip install flake8==7.3.0 pytest==9.1.1
+        # --only-binary=:all: is intentionally not used here: some of requirements.txt's
+        # pins (e.g. matplotlib==3.9.0) have no wheel for every Python version in this
+        # build matrix, so forcing wheel-only installs breaks those jobs outright.
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,7 +33,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip==25.2
         python -m pip install flake8==7.3.0 pytest==9.1.1
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8


### PR DESCRIPTION
Fixes the pip-install-itself instance of SonarCloud python:S8544 at .github/workflows/python-package.yml:36. Not fixed: the requirements.txt install (line 38) also flagged by S8544, and the S8541 finding recommending --only-binary=:all: on that same line. Verified locally that --only-binary=:all: fails outright, since matplotlib==3.9.0 (and likely other pins) have no wheel for some of the matrix's Python versions; fully hash-locking transitive dependencies across a 5-version build matrix is a much larger, riskier change than is safe to make without being able to test each of those environments.

## Summary by Sourcery

Build:
- Pin pip to version 25.2 in the GitHub Actions Python workflow dependency installation step.