### PR TITLE
Pin pip version in the Install dependencies step

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip==25.2
           python -m pip install pytest==9.1.1 pytest-cov==7.1.0
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -61,8 +61,13 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Exact-pinned (not a range) since SonarCloud's dependency-locking rule
+          # requires a single resolved version, not a compatible-release range.
           python -m pip install --upgrade pip==25.2
           python -m pip install pytest==9.1.1 pytest-cov==7.1.0
+          # --only-binary=:all: is intentionally not used here: some of requirements.txt's
+          # pins (e.g. matplotlib==3.9.0) have no wheel for every Python version this
+          # workflow may run under, so forcing wheel-only installs would break it outright.
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Test with coverage


### PR DESCRIPTION
Fixes the pip-install-itself instance of SonarCloud python:S8544 at .github/workflows/sonarcloud.yml:64. Not fixed: the requirements.txt install (line 66) also flagged by S8544, and the S8541 finding recommending --only-binary=:all: on that same line — verified locally that flag fails outright because matplotlib==3.9.0 (and likely other pins) have no wheel for some of the matrix's Python versions.

## Summary by Sourcery

CI:
- Update the SonarCloud workflow to install a fixed pip==25.2 version instead of upgrading to the latest pip.