### PR TITLE
Add scripts for common GitHub PR/CI maintenance tasks

### DIFF
--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -1,6 +1,6 @@
 # GitHub interaction scripts
 
-Small `gh`-CLI wrappers for the recurring tasks involved in managing a batch
+Small `gh` CLI wrappers for the recurring tasks involved in managing a batch
 of open PRs (checks, conflicts, stale CI status, review comments). All
 scripts default `repo` to the current directory's git remote if omitted.
 

--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -1,0 +1,32 @@
+# GitHub interaction scripts
+
+Small `gh`-CLI wrappers for the recurring tasks involved in managing a batch
+of open PRs (checks, conflicts, stale CI status, review comments). All
+scripts default `repo` to the current directory's git remote if omitted.
+
+- **pr-sweep.sh** — one-shot overview of every open PR: mergeability,
+  conflicts, failing/pending checks, and outstanding review-comment counts.
+- **pr-detail.sh `<PR>`** — deep dive on one PR: full check list, SonarCloud
+  quality gate + open issues for that PR's diff, open code-scanning alerts on
+  its branch, and review comments.
+- **cancel-stale-runs.sh** — cancels superseded queued/in_progress runs (same
+  branch + workflow, older than the newest). Useful when a repo's workflows
+  don't set `concurrency: cancel-in-progress` and pushes/merges pile up a
+  large backlog. Pass `--dry-run` to preview.
+- **refresh-stale-check.sh `<PR>`** — re-runs the SonarCloud analysis
+  workflow for a PR when its GitHub code-scanning "SonarCloud" check shows a
+  stale failure for an issue that's already confirmed fixed (verify with
+  pr-detail.sh first).
+
+## Requirements
+
+- `gh` CLI, authenticated (`gh auth status`)
+- `python3` (used for JSON processing)
+
+## Example
+
+```sh
+scripts/github/pr-sweep.sh
+scripts/github/pr-detail.sh 76
+scripts/github/cancel-stale-runs.sh --dry-run
+```

--- a/scripts/github/cancel-stale-runs.sh
+++ b/scripts/github/cancel-stale-runs.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Cancel superseded GitHub Actions runs: when a branch gets pushed to multiple
+# times (or master gets several merges back-to-back) without
+# `concurrency: cancel-in-progress` configured, every push queues a full new
+# run instead of cancelling the one still queued from the previous push. This
+# keeps only the newest queued/in_progress run per (branch, workflow) pair and
+# cancels the rest, freeing up concurrency slots.
+#
+# Usage:
+#   scripts/github/cancel-stale-runs.sh [repo] [--dry-run]
+
+set -euo pipefail
+
+REPO="${1:-}"
+DRY_RUN=false
+for arg in "$@"; do
+    [ "$arg" = "--dry-run" ] && DRY_RUN=true
+done
+if [ -z "$REPO" ] || [ "$REPO" = "--dry-run" ]; then
+    REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+fi
+
+gh run list --repo "$REPO" --limit 150 \
+    --json databaseId,status,headBranch,workflowName,createdAt \
+    | python3 -c "
+import json, sys
+from collections import defaultdict
+
+data = json.load(sys.stdin)
+not_done = [d for d in data if d['status'] in ('queued', 'in_progress')]
+
+by_branch_wf = defaultdict(list)
+for d in not_done:
+    by_branch_wf[(d['headBranch'], d['workflowName'])].append(d)
+
+to_cancel = []
+for runs in by_branch_wf.values():
+    if len(runs) > 1:
+        runs_sorted = sorted(runs, key=lambda r: r['createdAt'], reverse=True)
+        to_cancel.extend(r['databaseId'] for r in runs_sorted[1:])
+
+print(f'{len(not_done)} active runs, {len(to_cancel)} superseded', file=sys.stderr)
+for rid in to_cancel:
+    print(rid)
+" > /tmp/stale_runs_to_cancel.$$
+
+count=$(wc -l < /tmp/stale_runs_to_cancel.$$)
+if [ "$count" -eq 0 ]; then
+    echo "No stale runs to cancel."
+    rm -f /tmp/stale_runs_to_cancel.$$
+    exit 0
+fi
+
+if [ "$DRY_RUN" = true ]; then
+    echo "Would cancel $count run(s):"
+    cat /tmp/stale_runs_to_cancel.$$
+else
+    while read -r rid; do
+        gh run cancel "$rid" --repo "$REPO" 2>&1 || true
+    done < /tmp/stale_runs_to_cancel.$$
+fi
+
+rm -f /tmp/stale_runs_to_cancel.$$

--- a/scripts/github/pr-detail.sh
+++ b/scripts/github/pr-detail.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Deep-dive on a single PR: all check statuses, SonarCloud quality gate +
+# open issues for that PR's diff, open GitHub code-scanning alerts on its
+# branch, and review comments not authored by the repo owner.
+#
+# Usage:
+#   scripts/github/pr-detail.sh <PR> [repo] [sonar-project-key]
+
+set -euo pipefail
+
+PR="${1:?usage: pr-detail.sh <PR> [repo] [sonar-project-key]}"
+REPO="${2:-}"
+SONAR_PROJECT_KEY="${3:-}"
+
+if [ -z "$REPO" ]; then
+    REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+fi
+if [ -z "$SONAR_PROJECT_KEY" ]; then
+    # Best-effort guess from the SonarCloud workflow file, if present.
+    SONAR_PROJECT_KEY=$(grep -h "sonar.projectKey" .github/workflows/*.yml 2>/dev/null \
+        | head -1 | sed -E 's/.*projectKey=([^ ]+).*/\1/')
+fi
+
+BRANCH=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq .headRefName)
+OWNER=$(gh repo view "$REPO" --json owner --jq .owner.login)
+
+echo "== PR #$PR ($BRANCH) checks =="
+gh pr checks "$PR" --repo "$REPO" 2>&1 || true
+
+if [ -n "$SONAR_PROJECT_KEY" ]; then
+    echo
+    echo "== SonarCloud quality gate ($SONAR_PROJECT_KEY, PR $PR) =="
+    curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=${SONAR_PROJECT_KEY}&pullRequest=${PR}" \
+        | python3 -c "
+import json, sys
+d = json.load(sys.stdin)['projectStatus']
+print('status:', d['status'])
+for c in d['conditions']:
+    if c['status'] == 'ERROR':
+        print(' ERROR:', c['metricKey'], 'actual=', c['actualValue'])
+"
+
+    echo
+    echo "== SonarCloud open issues on this PR's diff =="
+    curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_PROJECT_KEY}&pullRequest=${PR}&resolved=false" \
+        | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+issues = d['issues']
+if not issues:
+    print('(none)')
+for i in issues:
+    print(i['type'], i['severity'], i['rule'], i['component'].split(':', 1)[-1], i.get('line'), '-', i['message'])
+"
+fi
+
+echo
+echo "== Open GitHub code-scanning alerts on $BRANCH =="
+gh api "repos/$REPO/code-scanning/alerts?state=open&ref=refs/heads/$BRANCH" \
+    --jq 'if length==0 then "(none)" else .[] | "\(.rule.id) \(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)" end'
+
+echo
+echo "== Review comments not from $OWNER =="
+gh api "repos/$REPO/pulls/$PR/comments" \
+    --jq "[.[] | select(.user.login != \"$OWNER\")] | if length==0 then \"(none)\" else .[] | \"[\(.id)] \(.path):\(.line) - \(.body[0:120])\" end"

--- a/scripts/github/pr-sweep.sh
+++ b/scripts/github/pr-sweep.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Summarize every open PR's CI status, mergeability, and outstanding review
+# comments in one pass. Requires the `gh` CLI to be authenticated.
+#
+# Usage:
+#   scripts/github/pr-sweep.sh [repo]
+#
+# repo defaults to the current directory's git remote if omitted.
+
+set -euo pipefail
+
+REPO="${1:-}"
+if [ -z "$REPO" ]; then
+    REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+fi
+
+echo "== Open PRs on $REPO =="
+gh pr list --repo "$REPO" --state open --limit 100 \
+    --json number,headRefName,mergeable,mergeStateStatus \
+    --jq '.[] | "\(.number)\t\(.headRefName)\t\(.mergeable)\t\(.mergeStateStatus)"' \
+    | column -t -s $'\t'
+
+echo
+echo "== Conflicting PRs =="
+gh pr list --repo "$REPO" --state open --limit 100 \
+    --json number,headRefName,mergeable \
+    --jq '[.[] | select(.mergeable=="CONFLICTING")] | if length==0 then "(none)" else .[] | "\(.number)\t\(.headRefName)" end'
+
+echo
+echo "== Failing / pending checks per PR =="
+for pr in $(gh pr list --repo "$REPO" --state open --limit 100 --json number --jq '.[].number'); do
+    checks=$(gh pr checks "$pr" --repo "$REPO" 2>&1 || true)
+    fails=$(echo "$checks" | awk -F'\t' '$2=="fail"{print $1}')
+    pending=$(echo "$checks" | awk -F'\t' '$2=="pending"{print $1}')
+    if [ -n "$fails" ]; then
+        echo "PR $pr FAILING: $(echo "$fails" | paste -sd, -)"
+    elif [ -n "$pending" ]; then
+        echo "PR $pr PENDING: $(echo "$pending" | paste -sd, -)"
+    else
+        echo "PR $pr: all green"
+    fi
+done
+
+echo
+echo "== Review comments not authored by the repo owner =="
+OWNER=$(gh repo view "$REPO" --json owner --jq .owner.login)
+for pr in $(gh pr list --repo "$REPO" --state open --limit 100 --json number --jq '.[].number'); do
+    count=$(gh api "repos/$REPO/pulls/$pr/comments" --jq "[.[] | select(.user.login != \"$OWNER\")] | length")
+    echo "PR $pr: $count"
+done

--- a/scripts/github/refresh-stale-check.sh
+++ b/scripts/github/refresh-stale-check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Re-run the "SonarCloud analysis" workflow for a PR's latest commit.
+#
+# Occasionally the separate github-advanced-security "SonarCloud" check (not
+# the "SonarCloud Code Analysis"/"SonarCloud analysis" checks) reports a
+# failure for a finding that has already been fixed and confirmed resolved
+# (0 open SonarCloud issues, 0 open code-scanning alerts for that commit) -
+# it just hasn't refreshed. Re-running the workflow run that produced it
+# regenerates the check with current results.
+#
+# This script only re-runs the workflow; it does NOT verify the finding is
+# actually already fixed first - do that manually (see pr-detail.sh) before
+# using this, otherwise you'll just get the same failure again.
+#
+# Usage:
+#   scripts/github/refresh-stale-check.sh <PR> [repo] [workflow-name]
+
+set -euo pipefail
+
+PR="${1:?usage: refresh-stale-check.sh <PR> [repo] [workflow-name]}"
+REPO="${2:-}"
+WORKFLOW_NAME="${3:-SonarCloud analysis}"
+
+if [ -z "$REPO" ]; then
+    REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+fi
+
+BRANCH=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq .headRefName)
+
+RUN_ID=$(gh run list --repo "$REPO" --branch "$BRANCH" --limit 20 \
+    --json databaseId,workflowName,createdAt \
+    --jq "[.[] | select(.workflowName == \"$WORKFLOW_NAME\")] | sort_by(.createdAt) | last | .databaseId")
+
+if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+    echo "No '$WORKFLOW_NAME' run found for $BRANCH" >&2
+    exit 1
+fi
+
+echo "Re-running $WORKFLOW_NAME run $RUN_ID for PR #$PR ($BRANCH)"
+gh run rerun "$RUN_ID" --repo "$REPO"


### PR DESCRIPTION
## Summary
- Formalizes the ad-hoc `gh` CLI commands used repeatedly while monitoring/fixing the batch of `sonar/*` PRs this session into reusable scripts under `scripts/github/`.
- `pr-sweep.sh` - overview of every open PR's checks, mergeability, and outstanding review comments
- `pr-detail.sh <PR>` - deep dive on one PR (checks, SonarCloud quality gate + open issues, code-scanning alerts, review comments)
- `cancel-stale-runs.sh` - cancels superseded queued/in_progress runs when a repo's workflows lack `concurrency: cancel-in-progress` (this repo's do)
- `refresh-stale-check.sh <PR>` - re-runs the SonarCloud analysis workflow to clear a stale github-advanced-security check for an already-fixed finding

## Test plan
- [x] `chmod +x` verified on all 4 scripts (100755 in git)
- [x] Ran each script against this repo live and confirmed correct output (pr-sweep.sh, pr-detail.sh 86, cancel-stale-runs.sh --dry-run, refresh-stale-check.sh resolves the right run id)
- [x] `pytest tests/` still passes (scripts don't touch application code)

## Summary by Sourcery

Add reusable GitHub CLI helper scripts for inspecting PR health and managing CI runs, along with brief documentation under scripts/github/.

New Features:
- Introduce pr-sweep.sh to summarize open PRs’ mergeability, conflicts, CI status, and review comment counts for a repository.
- Introduce pr-detail.sh to show a single PR’s checks, SonarCloud quality gate and issues, code-scanning alerts, and reviewer comments.
- Introduce cancel-stale-runs.sh to identify and cancel superseded queued or in-progress GitHub Actions runs per branch and workflow, with optional dry-run mode.
- Introduce refresh-stale-check.sh to rerun the most recent SonarCloud analysis workflow for a PR’s branch to refresh stale SonarCloud check results.

Documentation:
- Add README under scripts/github/ describing the GitHub helper scripts, their requirements, and example usage.