### PR TITLE
Add Claude Code skills for SonarCloud and GitHub PR maintenance

### DIFF
--- a/.claude/skills/github-pr-maintenance/SKILL.md
+++ b/.claude/skills/github-pr-maintenance/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: github-pr-maintenance
+description: "Use this skill whenever asked to check on, monitor, or fix open pull requests for this repo (kejhy93/ProteinFolding) — CI status, review comments, merge conflicts, or a batch of PRs at once. Triggers include 'check my PRs', 'are the PRs green', 'check for merge conflicts', 'reply to PR comments', 'why is this PR failing'. Wraps the scripts in scripts/github/ and documents recurring failure patterns specific to this repo's CI setup, discovered while managing ~90 sonar/* cleanup PRs in one session."
+---
+
+# GitHub PR Maintenance
+
+## Scripts
+
+Use these instead of hand-rolling `gh` one-liners — they already handle the
+repo/owner defaults and edge cases:
+
+- `scripts/github/pr-sweep.sh` — overview of every open PR: mergeability,
+  conflicts, failing/pending checks, outstanding review-comment counts. Run
+  this first for any "check my PRs" style request.
+- `scripts/github/pr-detail.sh <PR>` — deep dive on one PR: full check list,
+  SonarCloud quality gate + open issues for that PR's diff, open
+  code-scanning alerts on its branch, review comments. Run this when a PR is
+  failing and you need to know why.
+- `scripts/github/cancel-stale-runs.sh [--dry-run]` — cancels superseded
+  queued/in_progress runs (same branch+workflow, older than the newest).
+  This repo's workflows do **not** set `concurrency: cancel-in-progress`, so
+  every push/merge queues a full new run without cancelling the one still
+  queued from the previous push — run this whenever the Actions queue looks
+  backed up (dozens of queued runs is normal after touching many PRs/merges
+  in a short window, not a sign of anything broken).
+- `scripts/github/refresh-stale-check.sh <PR>` — re-runs the "SonarCloud
+  analysis" workflow to clear a stale check (see below). Verify the finding
+  is actually fixed first with `pr-detail.sh` — this script just re-runs,
+  it doesn't check anything.
+
+All four take an optional `repo` argument; they default to the current
+directory's `gh repo view` remote (`kejhy93/ProteinFolding`).
+
+## Known recurring patterns (from managing ~90 sonar/* PRs)
+
+**Stale "SonarCloud" check.** There's a separate `SonarCloud` check (created
+by the `github-advanced-security` app from a SARIF upload) distinct from
+`SonarCloud Code Analysis` / `SonarCloud analysis`. It occasionally reports
+failure for a finding that's already fixed and confirmed resolved — verify
+with `pr-detail.sh <PR>` (0 open SonarCloud issues *and* 0 open code-scanning
+alerts for that PR's branch means it's stale), then run
+`refresh-stale-check.sh <PR>`. Don't spend time debugging the underlying
+finding again if both live sources already show clean.
+
+**Merge-conflict resolution dropping NOSONAR/fix state.** When resolving a
+conflict on one of the complexity-refactor branches by merging `origin/master`
+in, the correct resolution is almost always "keep HEAD, it's a superset" —
+master usually only has a smaller inline fix (e.g. a NOSONAR comment) for
+code this branch already restructured into an extracted method. After
+resolving, **grep the file for the specific suppression/fix master had**
+(e.g. `# NOSONAR`) and confirm HEAD's version still has it on the equivalent
+line in the extracted method — it's easy to accidentally drop it, which
+reintroduces the exact SonarCloud finding the PR was created to fix. This has
+happened repeatedly on file:branch pairs where multiple sonar/* PRs touch the
+same function.
+
+**Slow build matrix jobs.** `build (3.13)` and `build (3.14)` in the "Python
+package" workflow routinely take 15–20 minutes (installing/building
+numpy/scipy/torch for newer Python versions), while `build (3.10)`–`(3.12)`
+finish in under 2 minutes. A PR sitting with only those two jobs pending for
+10+ minutes is normal, not stuck — confirm with
+`gh run view --job <id>` that it's progressed past "Install dependencies"
+before assuming something's wrong.
+
+**Reviewer feedback that's out of scope.** Sourcery frequently suggests
+things that don't apply to a narrowly-scoped cleanup PR: renaming a
+project-wide misspelling (e.g. `sequance`/`pheronome`) that appears in dozens
+of files, adding backward-compat shims for internal (non-public-API)
+parameter renames, or fixing an unrelated pre-existing bug spotted in a
+complexity-refactor PR. The right response is usually a reply explaining the
+scope boundary, not a code change — unless the fix is genuinely self-contained
+to the one file already being touched (e.g. a misspelled identifier used
+nowhere else), in which case just fix it.

--- a/.claude/skills/sonarcloud-dashboard/SKILL.md
+++ b/.claude/skills/sonarcloud-dashboard/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: sonarcloud-dashboard
+description: "Use this skill whenever the user asks about SonarCloud, code quality, the quality gate, bugs, vulnerabilities, code smells, security hotspots, test coverage, or duplication for this project. Triggers include 'sonarcloud', 'sonar dashboard', 'code quality', 'quality gate', 'check sonar'. Pulls live data from the SonarCloud public API instead of guessing — this project's analysis is public, so no auth token is required."
+---
+
+# SonarCloud Dashboard
+
+## Project identity
+
+Found in `.github/workflows/sonarcloud.yml`:
+- Project key: `kejhy93_ProteinFolding`
+- Organization: `kejhy93`
+
+If the workflow file's `-Dsonar.projectKey` / `-Dsonar.organization` values ever change, re-read that file — don't assume these are still current.
+
+## Access
+
+The project analysis is public, so the SonarCloud REST API (`https://sonarcloud.io/api/...`) can be queried directly with `curl`, no `SONAR_TOKEN` needed. If a query ever returns 401/403, the project may have gone private — ask the user for a token in that case rather than guessing.
+
+## Common queries
+
+**Overall metrics** (bugs, vulnerabilities, code smells, coverage, duplication, ratings):
+```bash
+curl -s "https://sonarcloud.io/api/measures/component?component=kejhy93_ProteinFolding&metricKeys=alert_status,bugs,vulnerabilities,code_smells,coverage,duplicated_lines_density,ncloc,security_hotspots,sqale_rating,reliability_rating,security_rating"
+```
+
+**Quality gate status**:
+```bash
+curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=kejhy93_ProteinFolding"
+```
+Note: `"status":"NONE"` means no quality gate is attached/evaluated for this project, not that it's passing.
+
+**Recent analyses** (dates, commit revisions — cross-check `revision` against `git log` to tie a scan to a commit):
+```bash
+curl -s "https://sonarcloud.io/api/project_analyses/search?project=kejhy93_ProteinFolding&ps=10"
+```
+
+**Issue list** (bugs/vulnerabilities/code smells with file + line), filter by `types` (`BUG`, `VULNERABILITY`, `CODE_SMELL`) and/or `severities` (`BLOCKER`, `CRITICAL`, `MAJOR`, `MINOR`, `INFO`):
+```bash
+curl -s "https://sonarcloud.io/api/issues/search?componentKeys=kejhy93_ProteinFolding&types=VULNERABILITY&resolved=false&ps=50"
+```
+
+**Security hotspots** (separate endpoint from `issues/search`):
+```bash
+curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=kejhy93_ProteinFolding"
+```
+
+## Notes
+
+- Ratings are `1.0`–`5.0` mapping to `A`–`E` (1=A, 2=B, 3=C, 4=D, 5=E) for `sqale_rating` (maintainability), `reliability_rating`, `security_rating`.
+- Responses are JSON; pipe through `python3 -m json.tool` or `jq` if pretty-printing helps, but raw JSON is usually fine to parse directly.
+- When summarizing for the user, prefer a compact table of the key metrics over dumping raw JSON, and call out anything that looks off (e.g. vulnerability count high relative to LOC, hotspots at 0 despite vulnerabilities present) rather than just listing numbers.

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Claude Code local session state (permission allowlist etc.) - not shared
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Adds two Claude Code skills under `.claude/skills/`:
  - `sonarcloud-dashboard` - how to query this project's SonarCloud stats via the public API (project key, org, common endpoints).
  - `github-pr-maintenance` - wraps the `scripts/github/*.sh` tools (see #93) and documents recurring CI patterns discovered while managing a large batch of cleanup PRs this session: a stale github-advanced-security "SonarCloud" check, merge-conflict resolution accidentally dropping NOSONAR suppressions, slow `build (3.13)`/`(3.14)` matrix jobs, and reviewer feedback that's out of scope for a narrow PR.
- Gitignores `.claude/settings.local.json` (this session's local permission allowlist, not shared project config).

## Test plan
- [x] `pytest tests/` passes (docs/config only, no application code touched)

## Summary by Sourcery

Introduce Claude skills for SonarCloud monitoring and GitHub PR maintenance, and adjust gitignore for local Claude settings.

New Features:
- Add a SonarCloud dashboard skill describing how to query live quality metrics for the project via the public SonarCloud API.
- Add a GitHub PR maintenance skill documenting repository-specific CI patterns and how to use existing GitHub helper scripts for managing PRs.

Enhancements:
- Clarify expected behavior and common failure modes in CI, code review, and merge workflows for this repository to streamline PR maintenance.

Build:
- Ignore local Claude settings configuration file from version control to avoid committing session-specific allowlists.