### PR TITLE
Remove unreachable verbose print in AbstractSolver.__init__

### DIFF
--- a/abstract_solver.py
+++ b/abstract_solver.py
@@ -7,9 +7,6 @@ class AbstractSolver:
     def __init__(self, sequance):
         self.verbose = False
 
-        if self.verbose:
-            print("AbstractSolver -> init")
-
         self.sequance = sequance
         self.result_vector = Vector(self.sequance)
 


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9cbD7eWSkLlgP3u7i3`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9cbD7eWSkLlgP3u7i3) — rule `pythonbugs:S2583` at `abstract_solver.py:10`.

**Fix:** `self.verbose` is unconditionally set to `False` two lines above, so `if self.verbose: print(...)` always evaluates to false. Removed the unreachable print.

## Summary by Sourcery

Enhancements:
- Clean up AbstractSolver initialization by removing a redundant verbose print guarded by a constant-false condition.