### PR TITLE
Remove unreachable verbose print in Individual.__init__

### DIFF
--- a/data/individual.py
+++ b/data/individual.py
@@ -9,9 +9,6 @@ class Individual:
     def __init__(self, sequance):
         self.verbose = False
 
-        if self.verbose:
-            print("Individual -> init")
-
         self.vector = Vector(sequance)
         self.free_energy = None
 


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9cbD5xWSkLlgP3u7hB`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9cbD5xWSkLlgP3u7hB) — rule `pythonbugs:S2583` at `data/individual.py:12`.

**Fix:** `self.verbose` is unconditionally set to `False` two lines above, so `if self.verbose: print(...)` always evaluates to false. Removed the unreachable print.

## Summary by Sourcery

Bug Fixes:
- Eliminate a logically unreachable debug print guarded by a verbose flag that is always set to False.