### PR TITLE
Remove unreachable verbose print in Population.__init__

### DIFF
--- a/data/population.py
+++ b/data/population.py
@@ -13,9 +13,6 @@ class Population:
     def __init__(self, size_of_population):
         self.verbose = False
 
-        if self.verbose:
-            print("Create populatin")
-
         self.size_of_population = size_of_population
 
         self.individuals = []


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9cbD56WSkLlgP3u7hF`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9cbD56WSkLlgP3u7hF) — rule `pythonbugs:S2583` at `data/population.py:16`.

**Fix:** `self.verbose` is unconditionally set to `False` two lines above, so `if self.verbose: print(...)` always evaluates to false. Removed the unreachable print.

## Summary by Sourcery

Bug Fixes:
- Eliminate a conditionally executed print that was never reachable due to verbose being hardcoded to false.