### PR TITLE
Remove unreachable verbose print in Vector.__init__

### DIFF
--- a/data/vector.py
+++ b/data/vector.py
@@ -27,9 +27,6 @@ class Vector:
     def __init__(self, protein_sequance):
         self.verbose = False
 
-        if self.verbose:
-            print("Vector -> init")
-
         self.sequance = protein_sequance
 
         self.configuration = []


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9cbD6FWSkLlgP3u7he`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9cbD6FWSkLlgP3u7he) — rule `pythonbugs:S2583` at `data/vector.py:30`.

**Fix:** `self.verbose` is unconditionally set to `False` two lines above, so `if self.verbose: print(...)` always evaluates to false. Removed the unreachable print.

## Summary by Sourcery

Enhancements:
- Simplify the Vector initializer by removing an always-false verbose print block flagged by static analysis.