### PR TITLE
Remove always-true verbose condition in GeneticsAlgorithm.__init__

### DIFF
--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -61,8 +61,7 @@ class GeneticsAlgorithm(AbstractSolver):
         super().__init__(sequance)
         self.verboseGeneticsSolver = True
 
-        if self.verboseGeneticsSolver:
-            print("GeneticsAlgorithm -> init")
+        print("GeneticsAlgorithm -> init")
 
         self.counter_before_disaster = 0
 


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9cbD6VWSkLlgP3u7h6`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9cbD6VWSkLlgP3u7h6) — rule `pythonbugs:S2589` at `gen_algo/genetics_algorithm.py:64`.

**Fix:** `self.verboseGeneticsSolver` is unconditionally set to `True` two lines above, so `if self.verboseGeneticsSolver:` always evaluates to true in this scope. Removed the redundant guard and kept the `print` unconditional — no behavior change, just resolves the constant-condition finding.

## Summary by Sourcery

Enhancements:
- Streamline GeneticsAlgorithm initialization by printing the init message unconditionally instead of guarding it with an always-true verbose flag.