### PR TITLE
Rename getFirstPosition to get_first_position

### DIFF
--- a/sequance_optimization.py
+++ b/sequance_optimization.py
@@ -17,7 +17,7 @@ def check_hydropholic(amino):
         return False
 
 
-def getFirstPosition(sequance):
+def get_first_position(sequance):
     counter = 0
     while check_valid_index(counter, sequance) and check_hydropholic(sequance[counter]):
         counter += 1
@@ -34,7 +34,7 @@ def getLastPosition(sequance):
 
 
 def optimize_sequance(sequance):
-    counter_from_begin = getFirstPosition(sequance)
+    counter_from_begin = get_first_position(sequance)
     counter_from_end = getLastPosition(sequance)
 
     if counter_from_begin > counter_from_end:


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9cbD3JWSkLlgP3u7g6`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9cbD3JWSkLlgP3u7g6) — rule `python:S1542` at `sequance_optimization.py:20`.

**Fix:** function names must match `^[a-z_][a-z0-9_]*$`. Renamed `getFirstPosition` to `get_first_position` and updated its one call site in `optimize_sequance`. `getLastPosition` (flagged separately) is left untouched here — it's addressed in a separate PR to keep this one scoped to a single issue.

## Summary by Sourcery

Align function naming with Python style guidelines in sequance_optimization.

Enhancements:
- Rename getFirstPosition to get_first_position for PEP 8 and static analysis compliance.
- Update optimize_sequance to call the renamed get_first_position function.