### PR TITLE
Rename getLastPosition to get_last_position

### DIFF
--- a/sequance_optimization.py
+++ b/sequance_optimization.py
@@ -25,7 +25,7 @@ def getFirstPosition(sequance):
     return counter
 
 
-def getLastPosition(sequance):
+def get_last_position(sequance):
     counter = len(sequance) - 1
     while check_valid_index(counter, sequance) and check_hydropholic(sequance[counter]):
         counter -= 1
@@ -35,7 +35,7 @@ def getLastPosition(sequance):
 
 def optimize_sequance(sequance):
     counter_from_begin = getFirstPosition(sequance)
-    counter_from_end = getLastPosition(sequance)
+    counter_from_end = get_last_position(sequance)
 
     if counter_from_begin > counter_from_end:
         return []


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9cbD3JWSkLlgP3u7g7`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9cbD3JWSkLlgP3u7g7) — rule `python:S1542` at `sequance_optimization.py:28`.

**Fix:** function names must match `^[a-z_][a-z0-9_]*$`. Renamed `getLastPosition` to `get_last_position` and updated its one call site in `optimize_sequance`. `getFirstPosition` (flagged separately) is left untouched here — addressed in a separate PR (#100) to keep this one scoped to a single issue.

## Summary by Sourcery

Enhancements:
- Rename getLastPosition to get_last_position and update its single call site in optimize_sequance for consistent snake_case styling.