### PR TITLE
Use [[ instead of [ for the REPO check in pr-sweep.sh

### DIFF
--- a/scripts/github/pr-sweep.sh
+++ b/scripts/github/pr-sweep.sh
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 REPO="${1:-}"
-if [ -z "$REPO" ]; then
+if [[ -z "$REPO" ]]; then
     REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 fi
 


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9g38cltwDduk7p-ylI`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9g38cltwDduk7p-ylI) — rule `shelldre:S7688` at `scripts/github/pr-sweep.sh:13`.

**Fix:** replaced `[ -z "$REPO" ]` with `[[ -z "$REPO" ]]` — `[[` is the safer, bash-native conditional construct. Other `[`/`]` occurrences flagged as separate SonarCloud issues in this and other scripts are left untouched here to keep this PR scoped to a single issue.

## Summary by Sourcery

Bug Fixes:
- Prevent potential edge cases in the REPO empty check in pr-sweep.sh by switching from [ to [[ in the conditional.