### PR TITLE
Use [[ instead of [ for the --dry-run arg check in cancel-stale-runs.sh

### DIFF
--- a/scripts/github/cancel-stale-runs.sh
+++ b/scripts/github/cancel-stale-runs.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 REPO="${1:-}"
 DRY_RUN=false
 for arg in "$@"; do
-    [ "$arg" = "--dry-run" ] && DRY_RUN=true
+    [[ "$arg" = "--dry-run" ]] && DRY_RUN=true
 done
 if [ -z "$REPO" ] || [ "$REPO" = "--dry-run" ]; then
     REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9g38eYtwDduk7p-ylR`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9g38eYtwDduk7p-ylR) — rule `shelldre:S7688` at `scripts/github/cancel-stale-runs.sh:17`.

**Fix:** replaced `[ "$arg" = "--dry-run" ]` with `[[ "$arg" = "--dry-run" ]]` — `[[` is the safer, bash-native conditional construct. Other `[`/`]` occurrences flagged as separate SonarCloud issues are left untouched here to keep this PR scoped to a single issue.

## Summary by Sourcery

Bug Fixes:
- Ensure --dry-run flag detection in cancel-stale-runs.sh complies with shell best practices and SonarCloud rule shelldre:S7688.