### PR TITLE
Use [[ instead of [ for the REPO emptiness check in cancel-stale-runs.sh

### DIFF
--- a/scripts/github/cancel-stale-runs.sh
+++ b/scripts/github/cancel-stale-runs.sh
@@ -16,7 +16,7 @@ DRY_RUN=false
 for arg in "$@"; do
     [ "$arg" = "--dry-run" ] && DRY_RUN=true
 done
-if [ -z "$REPO" ] || [ "$REPO" = "--dry-run" ]; then
+if [[ -z "$REPO" ]] || [ "$REPO" = "--dry-run" ]; then
     REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 fi
 


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9g38eYtwDduk7p-ylS`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9g38eYtwDduk7p-ylS) — rule `shelldre:S7688` at `scripts/github/cancel-stale-runs.sh:19`.

**Fix:** replaced `[ -z "$REPO" ]` with `[[ -z "$REPO" ]]`. The second test on the same line (`[ "$REPO" = "--dry-run" ]`) is flagged as a separate SonarCloud issue and is addressed in a separate PR to keep this one scoped to a single finding.

## Summary by Sourcery

Enhancements:
- Switch the repository emptiness check in cancel-stale-runs.sh from single-bracket to double-bracket Bash test to satisfy static analysis and improve shell robustness.