### PR TITLE
Use [[ instead of [ for the --dry-run REPO check in cancel-stale-runs.sh

### DIFF
--- a/scripts/github/cancel-stale-runs.sh
+++ b/scripts/github/cancel-stale-runs.sh
@@ -16,7 +16,7 @@ DRY_RUN=false
 for arg in "$@"; do
     [ "$arg" = "--dry-run" ] && DRY_RUN=true
 done
-if [ -z "$REPO" ] || [ "$REPO" = "--dry-run" ]; then
+if [ -z "$REPO" ] || [[ "$REPO" = "--dry-run" ]]; then
     REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 fi
 


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9g38eYtwDduk7p-ylT`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9g38eYtwDduk7p-ylT) — rule `shelldre:S7688` at `scripts/github/cancel-stale-runs.sh:19`.

**Fix:** replaced `[ "$REPO" = "--dry-run" ]` with `[[ "$REPO" = "--dry-run" ]]`. The other test on the same line (`[ -z "$REPO" ]`) is flagged as a separate SonarCloud issue and addressed in PR #105 to keep this one scoped to a single finding.

## Summary by Sourcery

Bug Fixes:
- Resolve a SonarCloud-reported shell scripting issue by updating the REPO equality check to use [[ instead of [ for the --dry-run value.