### PR TITLE
Use [[ instead of [ for the count check in cancel-stale-runs.sh

### DIFF
--- a/scripts/github/cancel-stale-runs.sh
+++ b/scripts/github/cancel-stale-runs.sh
@@ -45,7 +45,7 @@ for rid in to_cancel:
 " > /tmp/stale_runs_to_cancel.$$
 
 count=$(wc -l < /tmp/stale_runs_to_cancel.$$)
-if [ "$count" -eq 0 ]; then
+if [[ "$count" -eq 0 ]]; then
     echo "No stale runs to cancel."
     rm -f /tmp/stale_runs_to_cancel.$$
     exit 0


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9g38eYtwDduk7p-ylU`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9g38eYtwDduk7p-ylU) — rule `shelldre:S7688` at `scripts/github/cancel-stale-runs.sh:48`.

**Fix:** replaced `[ "$count" -eq 0 ]` with `[[ "$count" -eq 0 ]]` — `[[` is the safer, bash-native conditional construct.

## Summary by Sourcery

Enhancements:
- Adopt [[ for the run count comparison in cancel-stale-runs.sh to align with safer, modern bash practices.