### PR TITLE
Use [[ instead of [ for the DRY_RUN check in cancel-stale-runs.sh

### DIFF
--- a/scripts/github/cancel-stale-runs.sh
+++ b/scripts/github/cancel-stale-runs.sh
@@ -51,7 +51,7 @@ if [ "$count" -eq 0 ]; then
     exit 0
 fi
 
-if [ "$DRY_RUN" = true ]; then
+if [[ "$DRY_RUN" = true ]]; then
     echo "Would cancel $count run(s):"
     cat /tmp/stale_runs_to_cancel.$$
 else


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9g38eYtwDduk7p-ylV`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9g38eYtwDduk7p-ylV) — rule `shelldre:S7688` at `scripts/github/cancel-stale-runs.sh:54`.

**Fix:** replaced `[ "$DRY_RUN" = true ]` with `[[ "$DRY_RUN" = true ]]` — `[[` is the safer, bash-native conditional construct.

## Summary by Sourcery

Enhancements:
- Use bash [[ conditional for the DRY_RUN check in cancel-stale-runs.sh to improve script robustness and satisfy linting rules.