### PR TITLE
Use [[ instead of [ for the REPO check in pr-detail.sh

### DIFF
--- a/scripts/github/pr-detail.sh
+++ b/scripts/github/pr-detail.sh
@@ -12,7 +12,7 @@ PR="${1:?usage: pr-detail.sh <PR> [repo] [sonar-project-key]}"
 REPO="${2:-}"
 SONAR_PROJECT_KEY="${3:-}"
 
-if [ -z "$REPO" ]; then
+if [[ -z "$REPO" ]]; then
     REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 fi
 if [ -z "$SONAR_PROJECT_KEY" ]; then


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9g38dmtwDduk7p-ylL`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9g38dmtwDduk7p-ylL) — rule `shelldre:S7688` at `scripts/github/pr-detail.sh:15`.

**Fix:** replaced `[ -z "$REPO" ]` with `[[ -z "$REPO" ]]` — `[[` is the safer, bash-native conditional construct. Other `[`/`]` occurrences in this file are flagged as separate SonarCloud issues and addressed in separate PRs.

## Summary by Sourcery

Bug Fixes:
- Prevent potential issues in repository detection by using the Bash-native [[ conditional when REPO is unset.