### PR TITLE
Use [[ instead of [ for the SONAR_PROJECT_KEY check in pr-detail.sh

### DIFF
--- a/scripts/github/pr-detail.sh
+++ b/scripts/github/pr-detail.sh
@@ -15,7 +15,7 @@ SONAR_PROJECT_KEY="${3:-}"
 if [ -z "$REPO" ]; then
     REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 fi
-if [ -z "$SONAR_PROJECT_KEY" ]; then
+if [[ -z "$SONAR_PROJECT_KEY" ]]; then
     # Best-effort guess from the SonarCloud workflow file, if present.
     SONAR_PROJECT_KEY=$(grep -h "sonar.projectKey" .github/workflows/*.yml 2>/dev/null \
         | head -1 | sed -E 's/.*projectKey=([^ ]+).*/\1/')


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9g38dmtwDduk7p-ylM`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9g38dmtwDduk7p-ylM) — rule `shelldre:S7688` at `scripts/github/pr-detail.sh:18`.

**Fix:** replaced `[ -z "$SONAR_PROJECT_KEY" ]` with `[[ -z "$SONAR_PROJECT_KEY" ]]` — `[[` is the safer, bash-native conditional construct. Other `[`/`]` occurrences in this file are flagged as separate SonarCloud issues and addressed in separate PRs.

## Summary by Sourcery

Bug Fixes:
- Prevent potential shell compatibility or safety issues in SONAR_PROJECT_KEY detection by switching to the bash [[ ]] conditional.