### PR TITLE
Use [[ instead of [ for the SONAR_PROJECT_KEY branch guard in pr-detail.sh

### DIFF
--- a/scripts/github/pr-detail.sh
+++ b/scripts/github/pr-detail.sh
@@ -27,7 +27,7 @@ OWNER=$(gh repo view "$REPO" --json owner --jq .owner.login)
 echo "== PR #$PR ($BRANCH) checks =="
 gh pr checks "$PR" --repo "$REPO" 2>&1 || true
 
-if [ -n "$SONAR_PROJECT_KEY" ]; then
+if [[ -n "$SONAR_PROJECT_KEY" ]]; then
     echo
     echo "== SonarCloud quality gate ($SONAR_PROJECT_KEY, PR $PR) =="
     curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=${SONAR_PROJECT_KEY}&pullRequest=${PR}" \


### PR DESCRIPTION
Fixes SonarCloud issue [`AZ9g38dmtwDduk7p-ylN`](https://sonarcloud.io/project/issues?id=kejhy93_ProteinFolding&open=AZ9g38dmtwDduk7p-ylN) — rule `shelldre:S7688` at `scripts/github/pr-detail.sh:30`.

**Fix:** replaced `[ -n "$SONAR_PROJECT_KEY" ]` with `[[ -n "$SONAR_PROJECT_KEY" ]]` — `[[` is the safer, bash-native conditional construct. Other `[`/`]` occurrences in this file are flagged as separate SonarCloud issues and addressed in separate PRs.

## Summary by Sourcery

Enhancements:
- Switch the SONAR_PROJECT_KEY presence check in pr-detail.sh to use bash [[ ]] conditionals for improved robustness and static analysis compliance.