### PR TITLE
Use [[ instead of [ for the fails check in pr-sweep.sh

### DIFF
--- a/scripts/github/pr-sweep.sh
+++ b/scripts/github/pr-sweep.sh
@@ -32,7 +32,7 @@ for pr in $(gh pr list --repo "$REPO" --state open --limit 100 --json number --j
     checks=$(gh pr checks "$pr" --repo "$REPO" 2>&1 || true)
     fails=$(echo "$checks" | awk -F'\t' '$2=="fail"{print $1}')
     pending=$(echo "$checks" | awk -F'\t' '$2=="pending"{print $1}')
-    if [ -n "$fails" ]; then
+    if [[ -n "$fails" ]]; then
         echo "PR $pr FAILING: $(echo "$fails" | paste -sd, -)"
     elif [ -n "$pending" ]; then
         echo "PR $pr PENDING: $(echo "$pending" | paste -sd, -)"


### PR DESCRIPTION
**SonarCloud issue:** `AZ9g38cltwDduk7p-ylJ`
**Rule:** `shelldre:S7688` (MAJOR code smell)
**Location:** `scripts/github/pr-sweep.sh:35`

Replaced `[ -n "$fails" ]` with `[[ -n "$fails" ]]`. The `[[ ]]` construct avoids word-splitting/pathname-expansion pitfalls that plain `[` is subject to.

## Summary by Sourcery

Enhancements:
- Switch the failing-checks condition in pr-sweep.sh to use the [[ ]] test construct to avoid shell word-splitting/pathname expansion issues.