### PR TITLE
Use [[ instead of [ for the pending check in pr-sweep.sh

### DIFF
--- a/scripts/github/pr-sweep.sh
+++ b/scripts/github/pr-sweep.sh
@@ -34,7 +34,7 @@ for pr in $(gh pr list --repo "$REPO" --state open --limit 100 --json number --j
     pending=$(echo "$checks" | awk -F'\t' '$2=="pending"{print $1}')
     if [ -n "$fails" ]; then
         echo "PR $pr FAILING: $(echo "$fails" | paste -sd, -)"
-    elif [ -n "$pending" ]; then
+    elif [[ -n "$pending" ]]; then
         echo "PR $pr PENDING: $(echo "$pending" | paste -sd, -)"
     else
         echo "PR $pr: all green"


### PR DESCRIPTION
**SonarCloud issue:** `AZ9g38cltwDduk7p-ylK`
**Rule:** `shelldre:S7688` (MAJOR code smell)
**Location:** `scripts/github/pr-sweep.sh:37`

Replaced `[ -n "$pending" ]` with `[[ -n "$pending" ]]`. The `[[ ]]` construct avoids word-splitting/pathname-expansion pitfalls that plain `[` is subject to.

## Summary by Sourcery

Enhancements:
- Use the [[ ... ]] conditional construct for detecting pending checks in pr-sweep.sh to avoid shell word-splitting/pathname-expansion issues.