### PR TITLE
Use [[ instead of [ for the REPO check in refresh-stale-check.sh

### DIFF
--- a/scripts/github/refresh-stale-check.sh
+++ b/scripts/github/refresh-stale-check.sh
@@ -21,7 +21,7 @@ PR="${1:?usage: refresh-stale-check.sh <PR> [repo] [workflow-name]}"
 REPO="${2:-}"
 WORKFLOW_NAME="${3:-SonarCloud analysis}"
 
-if [ -z "$REPO" ]; then
+if [[ -z "$REPO" ]]; then
     REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 fi
 


### PR DESCRIPTION
**SonarCloud issue:** `AZ9g38d9twDduk7p-ylO`
**Rule:** `shelldre:S7688` (MAJOR code smell)
**Location:** `scripts/github/refresh-stale-check.sh:24`

Replaced `[ -z "$REPO" ]` with `[[ -z "$REPO" ]]`. The `[[ ]]` construct avoids word-splitting/pathname-expansion pitfalls that plain `[` is subject to.

## Summary by Sourcery

Enhancements:
- Improve robustness of the REPO emptiness check in the refresh-stale-check script by using [[ instead of [ to avoid shell word-splitting/pathname-expansion issues.