### PR TITLE
Use [[ instead of [ for the RUN_ID empty check in refresh-stale-check.sh

### DIFF
--- a/scripts/github/refresh-stale-check.sh
+++ b/scripts/github/refresh-stale-check.sh
@@ -31,7 +31,7 @@ RUN_ID=$(gh run list --repo "$REPO" --branch "$BRANCH" --limit 20 \
     --json databaseId,workflowName,createdAt \
     --jq "[.[] | select(.workflowName == \"$WORKFLOW_NAME\")] | sort_by(.createdAt) | last | .databaseId")
 
-if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+if [[ -z "$RUN_ID" ]] || [ "$RUN_ID" = "null" ]; then
     echo "No '$WORKFLOW_NAME' run found for $BRANCH" >&2
     exit 1
 fi


### PR DESCRIPTION
**SonarCloud issue:** `AZ9g38d9twDduk7p-ylP`
**Rule:** `shelldre:S7688` (MAJOR code smell)
**Location:** `scripts/github/refresh-stale-check.sh:34`

Replaced `[ -z "$RUN_ID" ]` with `[[ -z "$RUN_ID" ]]`. The `[[ ]]` construct avoids word-splitting/pathname-expansion pitfalls that plain `[` is subject to. (The second `[ "$RUN_ID" = "null" ]` test on the same line is a separate SonarCloud issue, addressed in a follow-up PR.)

## Summary by Sourcery

Bug Fixes:
- Prevent potential word-splitting or pathname expansion issues by using [[ -z "$RUN_ID" ]] in the RUN_ID check.