### PR TITLE
Use [[ instead of [ for the RUN_ID null check in refresh-stale-check.sh

### DIFF
--- a/scripts/github/refresh-stale-check.sh
+++ b/scripts/github/refresh-stale-check.sh
@@ -31,7 +31,7 @@ RUN_ID=$(gh run list --repo "$REPO" --branch "$BRANCH" --limit 20 \
     --json databaseId,workflowName,createdAt \
     --jq "[.[] | select(.workflowName == \"$WORKFLOW_NAME\")] | sort_by(.createdAt) | last | .databaseId")
 
-if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+if [ -z "$RUN_ID" ] || [[ "$RUN_ID" = "null" ]]; then
     echo "No '$WORKFLOW_NAME' run found for $BRANCH" >&2
     exit 1
 fi


### PR DESCRIPTION
**SonarCloud issue:** `AZ9g38d9twDduk7p-ylQ`
**Rule:** `shelldre:S7688` (MAJOR code smell)
**Location:** `scripts/github/refresh-stale-check.sh:34`

Replaced `[ "$RUN_ID" = "null" ]` with `[[ "$RUN_ID" = "null" ]]`. The `[[ ]]` construct avoids word-splitting/pathname-expansion pitfalls that plain `[` is subject to. (The `[ -z "$RUN_ID" ]` test earlier on the same line is a separate SonarCloud issue, addressed in a sibling PR — the two will need a trivial merge-conflict resolution once one lands.)

## Summary by Sourcery

Bug Fixes:
- Harden the RUN_ID null check in refresh-stale-check.sh by replacing the [ ] test with [[ ]] to avoid shell parsing pitfalls.