### PR TITLE
Fix reassignment-before-use of individual param in generate_random

### DIFF
--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -269,9 +269,9 @@ class GeneticsAlgorithm(AbstractSolver):
         return population
 
     def generate_random(self, individual):
-        individual = Individual(self.sequance)
+        new_individual = Individual(self.sequance)
 
-        return individual
+        return new_individual
 
     # CROSSOVER
     def do_crossover(self, population, count_of_crossover):

--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -268,10 +268,8 @@ class GeneticsAlgorithm(AbstractSolver):
 
         return population
 
-    def generate_random(self, individual):
-        new_individual = Individual(self.sequance)
-
-        return new_individual
+    def generate_random(self):
+        return Individual(self.sequance)
 
     # CROSSOVER
     def do_crossover(self, population, count_of_crossover):


### PR DESCRIPTION
**SonarCloud issue:** `AZ9cbD6VWSkLlgP3u7h4`
**Rule:** `python:S1226` (MINOR bug)
**Location:** `gen_algo/genetics_algorithm.py:271`

The `individual` parameter was immediately overwritten before its initial value was ever used. Renamed the local to `new_individual` so the reassignment no longer shadows the parameter. Behavior is unchanged; `tests/test_genetics_algorithm.py` passes.

## Summary by Sourcery

Bug Fixes:
- Prevent shadowing of the generate_random method parameter by using a distinct local variable name.