### PR TITLE
Replace unused loop index with _ in init_population

### DIFF
--- a/data/population.py
+++ b/data/population.py
@@ -26,7 +26,7 @@ class Population:
         """
         if self.verbose:
             print("Init of population")
-        for index_of_individual in range(self.size_of_population):
+        for _ in range(self.size_of_population):
             indi = Individual(vector.get_amino_sequance())
             indi.compute_free_energy()
 


### PR DESCRIPTION
**SonarCloud issue:** `AZ9cbD56WSkLlgP3u7hC`
**Rule:** `python:S1481` (MINOR code smell)
**Location:** `data/population.py:29`

`index_of_individual` was never read inside the loop body; replaced with `_`, the conventional unused-variable placeholder. `tests/test_ant.py`/population-related tests pass.

## Summary by Sourcery

Enhancements:
- Replace an unused loop index variable with the conventional placeholder to satisfy static analysis rules.