### PR TITLE
Replace unused loop index with _ in optimize_sequance

### DIFF
--- a/data/vector.py
+++ b/data/vector.py
@@ -152,7 +152,7 @@ class Vector:
 
     def optimize_sequance(self):
         self.sequance = optimize_sequance(self.sequance)
-        for i in range(len(self.sequance) - 1):
+        for _ in range(len(self.sequance) - 1):
             self.configuration.append(complex(0, 1))
 
         return self.sequance


### PR DESCRIPTION
**SonarCloud issue:** `AZ9cbD6FWSkLlgP3u7hM`
**Rule:** `python:S1481` (MINOR code smell)
**Location:** `data/vector.py:155`

`i` was never read inside the loop body; replaced with `_`, the conventional unused-variable placeholder. Full test suite (30 tests) passes.

## Summary by Sourcery

Enhancements:
- Clarify intent of the optimization loop by using the conventional unused-variable placeholder for its index.