### PR TITLE
Document skill learnings from sonar/* PR batch maintenance

### DIFF
--- a/.claude/skills/github-pr-maintenance/SKILL.md
+++ b/.claude/skills/github-pr-maintenance/SKILL.md
@@ -72,3 +72,47 @@ complexity-refactor PR. The right response is usually a reply explaining the
 scope boundary, not a code change — unless the fix is genuinely self-contained
 to the one file already being touched (e.g. a misspelled identifier used
 nowhere else), in which case just fix it.
+
+**`BLOCKED` with all-green checks and no conflict usually means an
+unresolved review thread, not a real problem.** This repo's branch protection
+has `required_conversation_resolution` enabled (check with
+`gh api repos/<owner>/<repo>/branches/master/protection`). A PR can show
+`mergeable: MERGEABLE` / `mergeStateStatus: BLOCKED` purely because a
+Sourcery/reviewer comment thread is unresolved — replying to the comment with
+`gh pr comment` does **not** resolve the thread. Query and resolve it via
+GraphQL:
+```bash
+gh api graphql -f query='
+query { repository(owner:"OWNER", name:"REPO") { pullRequest(number: PR) {
+  reviewThreads(first: 20) { nodes { id isResolved comments(first:1){nodes{body author{login}}} } }
+}}}'
+
+gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"THREAD_ID"}) { thread { isResolved } } }'
+```
+As the PR author you can resolve threads yourself once you've replied
+explaining the scope boundary (or pushed the requested fix). Sourcery itself
+auto-resolves a thread if a follow-up commit matches what it suggested — no
+action needed in that case.
+
+**A fix for one Sonar finding can expose a brand-new one on the same diff.**
+SonarCloud's "new code" quality gate evaluates the whole diff, not just the
+line the original issue was on. E.g. renaming a variable that was masking an
+unused-parameter finding (because it was previously "used" as a reassignment
+target) can turn a clean fix into a new `S1172` failure. Always check
+`pr-detail.sh`'s SonarCloud section even on a PR you just opened and expect
+to be clean — don't assume a freshly-created PR is safe from this. If a new
+finding shows up and it's a direct, self-contained consequence of your own
+diff (not a second, independent SonarCloud issue from the backlog), fixing it
+in a follow-up commit is in scope — it isn't "bundling," it's finishing the
+original fix properly.
+
+**Sibling `sonar/*` PRs opened in the same batch will conflict once one
+merges, if they touch the same or adjacent lines.** Each PR in a batch is
+branched off master independently (not off each other), so two PRs fixing
+different issues on the same line show no conflict while both are open —
+`pr-sweep.sh` reports them clean. As soon as one merges, the other flips to
+`mergeable: CONFLICTING` / `mergeStateStatus: DIRTY` against the new master.
+This repo's owner tends to auto-merge PRs within minutes of them going green,
+so re-run `pr-sweep.sh` periodically during a session rather than once at the
+start — the picture changes fast. Resolve the conflict per the "keep HEAD as
+superset" pattern above.

--- a/.claude/skills/sonarcloud-dashboard/SKILL.md
+++ b/.claude/skills/sonarcloud-dashboard/SKILL.md
@@ -42,8 +42,39 @@ curl -s "https://sonarcloud.io/api/issues/search?componentKeys=kejhy93_ProteinFo
 
 **Security hotspots** (separate endpoint from `issues/search`):
 ```bash
-curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=kejhy93_ProteinFolding"
+curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=kejhy93_ProteinFolding&ps=100"
 ```
+Note the response shape differs from `issues/search`: the hotspot count is
+at `paging.total`, not a top-level `total` key. `d.get('total')` on this
+response silently returns `None` even when there are zero (or many)
+hotspots — read `d['paging']['total']` instead, or check `len(d['hotspots'])`.
+
+**Rule details** (to understand what a rule actually requires before fixing
+it): needs an `organization` param or it 400s with "The 'organization'
+parameter is missing":
+```bash
+curl -s "https://sonarcloud.io/api/rules/show?key=<repo:RULE>&organization=kejhy93"
+```
+
+## Triaging which unresolved issues to actually fix
+
+- `issues/search`'s `creationDate` is not reliable for "oldest first"
+  ordering on this project — many long-standing findings carry an inherited
+  placeholder date (seen: `2015-12-24`) rather than when SonarCloud actually
+  flagged them. Sort by severity first (`BLOCKER > CRITICAL > MAJOR > MINOR
+  > INFO`) and only use `creationDate` as a same-severity tiebreaker, not as
+  a trustworthy age signal on its own.
+- **Known won't-fix: `githubactions:S8541` / `S8544` on the `pip install -r
+  requirements.txt` lines in `.github/workflows/sonarcloud.yml:71` and
+  `.github/workflows/python-package.yml:44`.** A prior session tried the
+  standard fix (`--only-binary :all:` for S8541), and it broke CI —
+  `requirements.txt` pins packages (e.g. `matplotlib==3.9.0`) with no wheel
+  for every Python version in the build matrix, so wheel-only installs failed
+  outright. It was reverted, with an explanatory comment left in both
+  workflow files. Don't re-open a `sonar/*` PR for these four issue
+  instances without a real plan for hash-locking (`--require-hashes` with
+  per-platform hashes verified against the full matrix) — re-adding
+  `--only-binary :all:` alone will just break the build again.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Documents that a `BLOCKED` mergeStateStatus with green checks and no conflict usually means an unresolved review thread (this repo has `required_conversation_resolution` on), which needs GraphQL to resolve, not a `gh pr comment` reply.
- Documents that a Sonar fix can expose a brand-new finding on the same diff (new-code quality gate scans the whole diff), and that fixing it in a follow-up commit is in-scope.
- Documents that sibling `sonar/*` PRs opened in the same batch will conflict once one merges if they touch the same/adjacent lines.
- Fixes a documented bug: `hotspots/search`'s count is at `paging.total`, not top-level `total`.
- Documents the `organization` param required by `rules/show`.

These are accumulated operational notes from a previous session's PR maintenance work that were never committed. No code changes — skill documentation only.

Co-Authored-By: Claude Sonnet 5

## Summary by Sourcery

Update internal skill documentation for GitHub PR maintenance and SonarCloud dashboard based on operational learnings from recent maintenance work.

Documentation:
- Clarify how to interpret `BLOCKED` merge state with all checks green and document resolving review threads via GitHub GraphQL.
- Explain that SonarCloud new-code analysis can surface additional findings after a fix and confirm follow-up fixes are in scope for the same PR batch.
- Document that concurrently opened `sonar/*` PRs in the same batch can develop merge conflicts once one is merged and advise re-running batch checks.
- Correct the documented behavior of the `hotspots/search` API to note hotspot counts are under `paging.total` and not a top-level `total` field.
- Document the required `organization` parameter for the `rules/show` API and add guidance on triaging and known won’t-fix SonarCloud issues.