### PR TITLE
Remove unused list_of_hydrophobilic in Vector.plot_config

### DIFF
--- a/data/vector.py
+++ b/data/vector.py
@@ -279,8 +279,6 @@ class Vector:
         list_of_real = []
         list_of_imag = []
 
-        list_of_hydrophobilic = []
-
         min_x, min_y = -1, -1
         max_x, max_y = 1, 1
 


### PR DESCRIPTION
Fixes SonarCloud issue `AZ9cbD6FWSkLlgP3u7hb` (rule `python:S1481`, MINOR) at `data/vector.py:282`.

`list_of_hydrophobilic` was declared in `Vector.plot_config` and never read afterward. Removed the dead assignment.

Co-Authored-By: Claude Sonnet 5

## Summary by Sourcery

Enhancements:
- Clean up Vector.plot_config by deleting an unused list_of_hydrophobilic variable.