### PR TITLE
Replace unused min_x with _ in Vector.plot_config

### DIFF
--- a/data/vector.py
+++ b/data/vector.py
@@ -281,7 +281,7 @@ class Vector:
 
         list_of_hydrophobilic = []
 
-        min_x, min_y = -1, -1
+        _, min_y = -1, -1
         max_x, max_y = 1, 1
 
         if index != None:


### PR DESCRIPTION
Fixes SonarCloud issue `AZ9cbD6FWSkLlgP3u7ha` (rule `python:S1481`, MINOR) at `data/vector.py:284`.

`min_x` from the `min_x, min_y = -1, -1` tuple assignment in `Vector.plot_config` was never read. Replaced with `_`.

Co-Authored-By: Claude Sonnet 5

## Summary by Sourcery

Enhancements:
- Replace an unused variable in Vector.plot_config with a conventional throwaway placeholder to satisfy static analysis.