### PR TITLE
Replace unused min_y with _ in Vector.plot_config

### DIFF
--- a/data/vector.py
+++ b/data/vector.py
@@ -281,7 +281,7 @@ class Vector:
 
         list_of_hydrophobilic = []
 
-        min_x, min_y = -1, -1
+        min_x, _ = -1, -1
         max_x, max_y = 1, 1
 
         if index != None:


### PR DESCRIPTION
Fixes SonarCloud issue `AZ9cbD6FWSkLlgP3u7hc` (rule `python:S1481`, MINOR) at `data/vector.py:284`.

`min_y` from the `min_x, min_y = -1, -1` tuple assignment in `Vector.plot_config` was never read. Replaced with `_`.

Note: this touches the same line as PR #122 (fixing the sibling `min_x` finding on the same line) — expect a conflict once one of the two merges; the other will need a quick rebase.

Co-Authored-By: Claude Sonnet 5

## Summary by Sourcery

Enhancements:
- Replace the unused min_y variable in Vector.plot_config with a throwaway placeholder to satisfy static analysis.