### PR TITLE
Replace unused max_x with _ in Vector.plot_config

### DIFF
--- a/data/vector.py
+++ b/data/vector.py
@@ -282,7 +282,7 @@ class Vector:
         list_of_hydrophobilic = []
 
         min_x, min_y = -1, -1
-        max_x, max_y = 1, 1
+        _, max_y = 1, 1
 
         if index != None:
             final_index = index + 1


### PR DESCRIPTION
Fixes SonarCloud issue `AZ9cbD6FWSkLlgP3u7hY` (rule `python:S1481`, MINOR) at `data/vector.py:285`.

`max_x` from the `max_x, max_y = 1, 1` tuple assignment in `Vector.plot_config` was never read. Replaced with `_`.

Note: this touches the same line as the sibling `max_y` fix (opened right after this one) — expect a conflict once one merges.

Co-Authored-By: Claude Sonnet 5

## Summary by Sourcery

Enhancements:
- Replace the unused max_x variable in Vector.plot_config with a throwaway placeholder to reflect that only max_y is used.