### PR TITLE
Rename constructor parameter MAX_GENERATION to max_generation

### DIFF
--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -38,16 +38,16 @@ COUNT_OF_ANTS = 8
 
 
 class GeneticsAlgorithm(AbstractSolver):
-    def __init__(self, sequance, MAX_GENERATION, POPULATION_SIZE,
+    def __init__(self, sequance, max_generation, POPULATION_SIZE,
                  COUNT_OF_MUTATION_PER_GENERATION, COUNT_OF_CROSSOVER_PER_GENERATION,
                  MUTATE_RATE, CROSSOVER_RATE, store_individuals_per_generation=True):
 
-        self.MAX_GENERATION = MAX_GENERATION
+        self.MAX_GENERATION = max_generation
         self.POPULATION_SIZE = POPULATION_SIZE
 
-        self.FREQUANCY_OF_HILL_CLIMBING = (int)(MAX_GENERATION / COUNT_OF_HILL_CLIMBING)
-        self.FREQUANCY_OF_SIMULATED_ANNEALING = (int)(MAX_GENERATION / COUNT_OF_SIMULATED_ANNEALING)
-        self.FREQUANCY_OF_ANT_COLONY = (int)(MAX_GENERATION / COUNT_OF_ANT_COLONY)
+        self.FREQUANCY_OF_HILL_CLIMBING = (int)(max_generation / COUNT_OF_HILL_CLIMBING)
+        self.FREQUANCY_OF_SIMULATED_ANNEALING = (int)(max_generation / COUNT_OF_SIMULATED_ANNEALING)
+        self.FREQUANCY_OF_ANT_COLONY = (int)(max_generation / COUNT_OF_ANT_COLONY)
 
         self.MUTATE_RATE = MUTATE_RATE
         self.CROSSOVER_RATE = CROSSOVER_RATE

--- a/tests/test_genetics_algorithm.py
+++ b/tests/test_genetics_algorithm.py
@@ -13,7 +13,7 @@ def make_solver(max_generation, population_size, monkeypatch, **kwargs):
     """
     solver = GeneticsAlgorithm(
         sequance=[0, 1, 1, 0, 1, 0],
-        MAX_GENERATION=max_generation,
+        max_generation=max_generation,
         POPULATION_SIZE=population_size,
         COUNT_OF_MUTATION_PER_GENERATION=0,
         COUNT_OF_CROSSOVER_PER_GENERATION=0,
@@ -37,7 +37,7 @@ def make_solver(max_generation, population_size, monkeypatch, **kwargs):
 def test_list_individuals_is_empty_after_init():
     solver = GeneticsAlgorithm(
         sequance=[0, 1, 1, 0],
-        MAX_GENERATION=1,
+        max_generation=1,
         POPULATION_SIZE=2,
         COUNT_OF_MUTATION_PER_GENERATION=0,
         COUNT_OF_CROSSOVER_PER_GENERATION=0,


### PR DESCRIPTION
Fixes SonarCloud issue `AZ9cbD6VWSkLlgP3u7hs` (rule `python:S117`, MINOR) at `gen_algo/genetics_algorithm.py:41`.

`MAX_GENERATION` didn't match the required parameter naming pattern (`^[_a-z][a-z0-9_]*$`). Renamed the parameter and its in-body uses to `max_generation`, keeping `self.MAX_GENERATION` as the attribute name (matches the existing pattern already used for `store_individuals_per_generation` → `self.STORE_INDIVIDUALS_PER_GENERATION`). Updated the keyword argument in `tests/test_genetics_algorithm.py`.

Note: sibling parameters on the same signature lines (`POPULATION_SIZE`, `COUNT_OF_CROSSOVER_PER_GENERATION`, etc.) are separate SonarCloud findings, fixed in their own PRs — expect conflicts on this multi-line signature once one merges.

Co-Authored-By: Claude Sonnet 5

## Summary by Sourcery

Rename the genetics algorithm constructor parameter for maximum generations to follow Python naming conventions and update its usages.

Enhancements:
- Align the GeneticsAlgorithm constructor parameter name for maximum generations with standard Python lower_snake_case naming.

Tests:
- Update tests to use the new max_generation keyword when constructing GeneticsAlgorithm instances.