### PR TITLE
Rename constructor parameter POPULATION_SIZE to population_size

### DIFF
--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -38,12 +38,12 @@ COUNT_OF_ANTS = 8
 
 
 class GeneticsAlgorithm(AbstractSolver):
-    def __init__(self, sequance, MAX_GENERATION, POPULATION_SIZE,
+    def __init__(self, sequance, MAX_GENERATION, population_size,
                  COUNT_OF_MUTATION_PER_GENERATION, COUNT_OF_CROSSOVER_PER_GENERATION,
                  MUTATE_RATE, CROSSOVER_RATE, store_individuals_per_generation=True):
 
         self.MAX_GENERATION = MAX_GENERATION
-        self.POPULATION_SIZE = POPULATION_SIZE
+        self.POPULATION_SIZE = population_size
 
         self.FREQUANCY_OF_HILL_CLIMBING = (int)(MAX_GENERATION / COUNT_OF_HILL_CLIMBING)
         self.FREQUANCY_OF_SIMULATED_ANNEALING = (int)(MAX_GENERATION / COUNT_OF_SIMULATED_ANNEALING)

--- a/tests/test_genetics_algorithm.py
+++ b/tests/test_genetics_algorithm.py
@@ -14,7 +14,7 @@ def make_solver(max_generation, population_size, monkeypatch, **kwargs):
     solver = GeneticsAlgorithm(
         sequance=[0, 1, 1, 0, 1, 0],
         MAX_GENERATION=max_generation,
-        POPULATION_SIZE=population_size,
+        population_size=population_size,
         COUNT_OF_MUTATION_PER_GENERATION=0,
         COUNT_OF_CROSSOVER_PER_GENERATION=0,
         MUTATE_RATE=0.0,
@@ -38,7 +38,7 @@ def test_list_individuals_is_empty_after_init():
     solver = GeneticsAlgorithm(
         sequance=[0, 1, 1, 0],
         MAX_GENERATION=1,
-        POPULATION_SIZE=2,
+        population_size=2,
         COUNT_OF_MUTATION_PER_GENERATION=0,
         COUNT_OF_CROSSOVER_PER_GENERATION=0,
         MUTATE_RATE=0.0,


### PR DESCRIPTION
Fixes SonarCloud issue `AZ9cbD6VWSkLlgP3u7hu` (rule `python:S117`, MINOR) at `gen_algo/genetics_algorithm.py:41`.

`POPULATION_SIZE` didn't match the required parameter naming pattern (`^[_a-z][a-z0-9_]*$`). Renamed the parameter to `population_size`, keeping `self.POPULATION_SIZE` as the attribute name. Updated the keyword argument in `tests/test_genetics_algorithm.py`.

Note: this shares the `__init__` signature line with `MAX_GENERATION` (fixed in PR #126) and other sibling findings — expect a conflict once one merges.

Co-Authored-By: Claude Sonnet 5

## Summary by Sourcery

Rename the genetics algorithm constructor population size parameter to follow Python naming conventions and update callers accordingly.

Enhancements:
- Align the GeneticsAlgorithm constructor parameter name for population size with Python's standard lower_snake_case style.

Tests:
- Update genetics algorithm tests to use the new population_size constructor keyword.