### PR TITLE
Rename constructor parameter COUNT_OF_CROSSOVER_PER_GENERATION to count_of_crossover_per_generation

### DIFF
--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -39,7 +39,7 @@ COUNT_OF_ANTS = 8
 
 class GeneticsAlgorithm(AbstractSolver):
     def __init__(self, sequance, MAX_GENERATION, POPULATION_SIZE,
-                 COUNT_OF_MUTATION_PER_GENERATION, COUNT_OF_CROSSOVER_PER_GENERATION,
+                 COUNT_OF_MUTATION_PER_GENERATION, count_of_crossover_per_generation,
                  MUTATE_RATE, CROSSOVER_RATE, store_individuals_per_generation=True):
 
         self.MAX_GENERATION = MAX_GENERATION
@@ -53,7 +53,7 @@ class GeneticsAlgorithm(AbstractSolver):
         self.CROSSOVER_RATE = CROSSOVER_RATE
 
         self.COUNT_OF_MUTATION_PER_GENERATION = COUNT_OF_MUTATION_PER_GENERATION
-        self.COUNT_OF_CROSSOVER_PER_GENERATION = COUNT_OF_CROSSOVER_PER_GENERATION
+        self.COUNT_OF_CROSSOVER_PER_GENERATION = count_of_crossover_per_generation
 
         self.STORE_INDIVIDUALS_PER_GENERATION = store_individuals_per_generation
         self.list_individuals = []

--- a/tests/test_genetics_algorithm.py
+++ b/tests/test_genetics_algorithm.py
@@ -16,7 +16,7 @@ def make_solver(max_generation, population_size, monkeypatch, **kwargs):
         MAX_GENERATION=max_generation,
         POPULATION_SIZE=population_size,
         COUNT_OF_MUTATION_PER_GENERATION=0,
-        COUNT_OF_CROSSOVER_PER_GENERATION=0,
+        count_of_crossover_per_generation=0,
         MUTATE_RATE=0.0,
         CROSSOVER_RATE=0.0,
         **kwargs,
@@ -40,7 +40,7 @@ def test_list_individuals_is_empty_after_init():
         MAX_GENERATION=1,
         POPULATION_SIZE=2,
         COUNT_OF_MUTATION_PER_GENERATION=0,
-        COUNT_OF_CROSSOVER_PER_GENERATION=0,
+        count_of_crossover_per_generation=0,
         MUTATE_RATE=0.0,
         CROSSOVER_RATE=0.0,
     )


### PR DESCRIPTION
Fixes SonarCloud issue `AZ9cbD6VWSkLlgP3u7hp` (rule `python:S117`, MINOR) at `gen_algo/genetics_algorithm.py:42`.

`COUNT_OF_CROSSOVER_PER_GENERATION` didn't match the required parameter naming pattern (`^[_a-z][a-z0-9_]*$`). Renamed the parameter to `count_of_crossover_per_generation`, keeping `self.COUNT_OF_CROSSOVER_PER_GENERATION` as the attribute name. Updated the keyword argument in `tests/test_genetics_algorithm.py`.

Note: shares the `__init__` signature line with the sibling `COUNT_OF_MUTATION_PER_GENERATION` finding (not yet fixed) — expect a conflict once one of the two is fixed and merged.

Co-Authored-By: Claude Sonnet 5

## Summary by Sourcery

Align constructor parameter naming in genetics algorithm with Python style guidelines and update usages accordingly.

Enhancements:
- Rename the GeneticsAlgorithm constructor parameter for crossover-per-generation to a lowercase, PEP 8–compliant identifier while retaining the existing attribute name.

Tests:
- Update genetics algorithm test helper and constructors to use the new crossover-per-generation parameter name.