### PR TITLE
Rename constructor parameter MUTATE_RATE to mutate_rate

### DIFF
--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -40,7 +40,7 @@ COUNT_OF_ANTS = 8
 class GeneticsAlgorithm(AbstractSolver):
     def __init__(self, sequance, max_generation, population_size,
                  COUNT_OF_MUTATION_PER_GENERATION, count_of_crossover_per_generation,
-                 MUTATE_RATE, CROSSOVER_RATE, store_individuals_per_generation=True):
+                 mutate_rate, CROSSOVER_RATE, store_individuals_per_generation=True):
 
         self.MAX_GENERATION = max_generation
         self.POPULATION_SIZE = population_size
@@ -49,7 +49,7 @@ class GeneticsAlgorithm(AbstractSolver):
         self.FREQUANCY_OF_SIMULATED_ANNEALING = (int)(max_generation / COUNT_OF_SIMULATED_ANNEALING)
         self.FREQUANCY_OF_ANT_COLONY = (int)(max_generation / COUNT_OF_ANT_COLONY)
 
-        self.MUTATE_RATE = MUTATE_RATE
+        self.MUTATE_RATE = mutate_rate
         self.CROSSOVER_RATE = CROSSOVER_RATE
 
         self.COUNT_OF_MUTATION_PER_GENERATION = COUNT_OF_MUTATION_PER_GENERATION

--- a/tests/test_genetics_algorithm.py
+++ b/tests/test_genetics_algorithm.py
@@ -17,7 +17,7 @@ def make_solver(max_generation, population_size, monkeypatch, **kwargs):
         population_size=population_size,
         COUNT_OF_MUTATION_PER_GENERATION=0,
         count_of_crossover_per_generation=0,
-        MUTATE_RATE=0.0,
+        mutate_rate=0.0,
         CROSSOVER_RATE=0.0,
         **kwargs,
     )
@@ -41,7 +41,7 @@ def test_list_individuals_is_empty_after_init():
         population_size=2,
         COUNT_OF_MUTATION_PER_GENERATION=0,
         count_of_crossover_per_generation=0,
-        MUTATE_RATE=0.0,
+        mutate_rate=0.0,
         CROSSOVER_RATE=0.0,
     )
 


### PR DESCRIPTION
Fixes SonarCloud issue `AZ9cbD6VWSkLlgP3u7ht` (rule `python:S117`, MINOR) at `gen_algo/genetics_algorithm.py:43`.

`MUTATE_RATE` didn't match the required parameter naming pattern (`^[_a-z][a-z0-9_]*$`). Renamed the parameter to `mutate_rate`, keeping `self.MUTATE_RATE` as the attribute name. Updated the keyword argument in `tests/test_genetics_algorithm.py`.

Note: shares the `__init__` signature line with the sibling `CROSSOVER_RATE` finding (fixed in its own PR) — expect a conflict once one merges.

Co-Authored-By: Claude Sonnet 5

## Summary by Sourcery

Rename the genetics algorithm constructor parameter for mutation rate to use a compliant snake_case name and update call sites accordingly.

Enhancements:
- Align the GeneticsAlgorithm.__init__ mutation rate parameter name with Python naming conventions while retaining the existing attribute name.

Tests:
- Update genetics algorithm tests to use the new mutation rate parameter name in solver construction.