### PR TITLE
Rename constructor parameter CROSSOVER_RATE to crossover_rate

### DIFF
--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -40,7 +40,7 @@ COUNT_OF_ANTS = 8
 class GeneticsAlgorithm(AbstractSolver):
     def __init__(self, sequance, max_generation, population_size,
                  COUNT_OF_MUTATION_PER_GENERATION, count_of_crossover_per_generation,
-                 MUTATE_RATE, CROSSOVER_RATE, store_individuals_per_generation=True):
+                 MUTATE_RATE, crossover_rate, store_individuals_per_generation=True):
 
         self.MAX_GENERATION = max_generation
         self.POPULATION_SIZE = population_size
@@ -50,7 +50,7 @@ class GeneticsAlgorithm(AbstractSolver):
         self.FREQUANCY_OF_ANT_COLONY = (int)(max_generation / COUNT_OF_ANT_COLONY)
 
         self.MUTATE_RATE = MUTATE_RATE
-        self.CROSSOVER_RATE = CROSSOVER_RATE
+        self.CROSSOVER_RATE = crossover_rate
 
         self.COUNT_OF_MUTATION_PER_GENERATION = COUNT_OF_MUTATION_PER_GENERATION
         self.COUNT_OF_CROSSOVER_PER_GENERATION = count_of_crossover_per_generation

--- a/tests/test_genetics_algorithm.py
+++ b/tests/test_genetics_algorithm.py
@@ -18,7 +18,7 @@ def make_solver(max_generation, population_size, monkeypatch, **kwargs):
         COUNT_OF_MUTATION_PER_GENERATION=0,
         count_of_crossover_per_generation=0,
         MUTATE_RATE=0.0,
-        CROSSOVER_RATE=0.0,
+        crossover_rate=0.0,
         **kwargs,
     )
     solver.verboseGeneticsSolver = False
@@ -42,7 +42,7 @@ def test_list_individuals_is_empty_after_init():
         COUNT_OF_MUTATION_PER_GENERATION=0,
         count_of_crossover_per_generation=0,
         MUTATE_RATE=0.0,
-        CROSSOVER_RATE=0.0,
+        crossover_rate=0.0,
     )
 
     assert solver.list_individuals == []


### PR DESCRIPTION
Fixes SonarCloud issue `AZ9cbD6VWSkLlgP3u7hr` (rule `python:S117`, MINOR) at `gen_algo/genetics_algorithm.py:43`.

`CROSSOVER_RATE` didn't match the required parameter naming pattern (`^[_a-z][a-z0-9_]*$`). Renamed the parameter to `crossover_rate`, keeping `self.CROSSOVER_RATE` as the attribute name. Updated the keyword argument in `tests/test_genetics_algorithm.py`.

Note: shares the `__init__` signature line with the sibling `MUTATE_RATE` finding (fixed in PR #130) — expect a conflict once one merges.

Co-Authored-By: Claude Sonnet 5

## Summary by Sourcery

Rename the genetics algorithm constructor parameter for crossover rate to follow Python naming conventions and update tests accordingly.

Enhancements:
- Align the GeneticsAlgorithm constructor parameter name for crossover rate with standard Python lowercase naming.

Tests:
- Update genetics algorithm test helpers and initialization calls to use the new crossover_rate keyword argument.