### PR TITLE
Remove unused local variable energy_of_best_individual_of_population

### DIFF
--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -84,7 +84,6 @@ class GeneticsAlgorithm(AbstractSolver):
         population.init_population(self.result_vector)
 
         best_individual_of_population, _ = population.pick_random_individual()
-        energy_of_best_individual_of_population = 100000000
 
         if self.verboseGeneticsSolver:
             print(" Init population: ", population)


### PR DESCRIPTION
Fixes SonarCloud issue `AZ9cbD6VWSkLlgP3u7hw` (rule `python:S1481`, MINOR) at `gen_algo/genetics_algorithm.py:87`.

`energy_of_best_individual_of_population` was assigned a placeholder value in `solve()` and never read afterward. Removed the dead assignment.

Co-Authored-By: Claude Sonnet 5

## Summary by Sourcery

Enhancements:
- Eliminate a redundant local variable from the solve() method to simplify the genetics algorithm implementation.