### PR TITLE
Remove unused local variable energy_of_best_individual_of_iteration

### DIFF
--- a/gen_algo/genetics_algorithm.py
+++ b/gen_algo/genetics_algorithm.py
@@ -159,8 +159,6 @@ class GeneticsAlgorithm(AbstractSolver):
         # Pick best individual from population and compare with best individual found
         best_individual_of_iteration, average_fitness = population.pick_best_individual()
 
-        energy_of_best_individual_of_iteration = best_individual_of_iteration.compute_free_energy()
-
         best_individual_of_population = self.get_best_individual(best_individual_of_iteration,
                                                                  best_individual_of_population)
 


### PR DESCRIPTION
Fixes SonarCloud issue `AZ9cbD6VWSkLlgP3u7hy` (rule `python:S1481`, MINOR) at `gen_algo/genetics_algorithm.py:162`.

`energy_of_best_individual_of_iteration` captured the return value of `best_individual_of_iteration.compute_free_energy()`, which was never read. `Individual.get_free_energy()` lazily calls `compute_free_energy()` if `free_energy` isn't set yet (`data/individual.py:46-48`), so removing this redundant call doesn't change behavior — confirmed via the existing test suite.

Co-Authored-By: Claude Sonnet 5

## Summary by Sourcery

Enhancements:
- Eliminate a redundant compute_free_energy() call whose result was never used, without changing the algorithm's behavior.