### PR TITLE
Add tests for data/vector.py (coverage 46.2% -> 83%)

### DIFF
--- a/data/vector.py
+++ b/data/vector.py
@@ -64,7 +64,7 @@ class Vector:
         self.space_configuration_counter = Counter(self.space_configuration)
 
     def check_space_configuration_counter(self, direction, index):
-        self.space_configuration = self.compute_space_configuration_to_index(index)
+        self.space_configuration = self.compute_space_configuration(index)
         print(SPACE_CONFIGURATION_LOG_PREFIX, self.space_configuration)
 
         new_space_config = self.space_configuration[-1] + direction

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -44,6 +44,26 @@ def test_check_space_configuration_counter_false_when_collision():
     assert vector.check_space_configuration_counter(complex(-1, 0), 0) is False
 
 
+def test_check_space_configuration_counter_false_when_collision_at_non_zero_index():
+    # Path: (0,0) -> (1,0) -> (1,1) -> (0,1); from (0,1), turning to (0,-1) walks
+    # straight back onto the already-visited origin.
+    vector = make_vector(
+        sequance=[1, 0, 1, 1],
+        configuration=[complex(1, 0), complex(0, 1), complex(-1, 0)],
+    )
+
+    assert vector.check_space_configuration_counter(complex(0, -1), 2) is False
+
+
+def test_check_space_configuration_counter_true_at_non_zero_index_without_collision():
+    vector = make_vector(
+        sequance=[1, 0, 1, 1],
+        configuration=[complex(1, 0), complex(0, 1), complex(-1, 0)],
+    )
+
+    assert vector.check_space_configuration_counter(complex(0, 1), 2) is True
+
+
 def test_print_config_handles_all_directions_and_default():
     vector = make_vector()
 
@@ -126,6 +146,39 @@ def test_optimize_sequance_trims_and_extends_configuration():
     assert len(vector.configuration) == original_len + (len(result) - 1)
 
 
+def test_optimize_sequance_with_no_zeros_is_unchanged():
+    vector = make_vector(sequance=[1, 1, 1])
+    original_len = len(vector.configuration)
+
+    result = vector.optimize_sequance()
+
+    assert result == [1, 1, 1]
+    assert vector.sequance == [1, 1, 1]
+    assert len(vector.configuration) == original_len + (len(result) - 1)
+
+
+def test_optimize_sequance_with_leading_zeros_only():
+    vector = make_vector(sequance=[0, 0, 1, 1])
+    original_len = len(vector.configuration)
+
+    result = vector.optimize_sequance()
+
+    assert result == [1, 1]
+    assert vector.sequance == [1, 1]
+    assert len(vector.configuration) == original_len + (len(result) - 1)
+
+
+def test_optimize_sequance_with_trailing_zeros_only():
+    vector = make_vector(sequance=[1, 1, 0, 0])
+    original_len = len(vector.configuration)
+
+    result = vector.optimize_sequance()
+
+    assert result == [1, 1]
+    assert vector.sequance == [1, 1]
+    assert len(vector.configuration) == original_len + (len(result) - 1)
+
+
 def test_get_space_configuration_set_returns_counter():
     vector = make_vector(configuration=[complex(1, 0)])
     vector.update_space_configuration_counter()
@@ -149,6 +202,17 @@ def test_get_space_configuration_returns_full_when_index_none():
     result = vector.get_space_configuration()
 
     assert result == vector.space_configuration
+
+
+def test_get_space_configuration_returns_slice_without_recomputing_when_precomputed():
+    vector = make_vector(sequance=[1, 0, 1, 1], configuration=[complex(1, 0), complex(0, 1), complex(1, 0)])
+    vector.compute_space_configuration()
+    precomputed = list(vector.space_configuration)
+
+    result = vector.get_space_configuration(index=1)
+
+    assert result == precomputed[0:2]
+    assert vector.space_configuration == precomputed
 
 
 def test_get_axis_covers_min_and_max_expansion_in_all_directions():

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,0 +1,238 @@
+from collections import Counter
+
+from data.vector import Vector
+
+
+def make_vector(sequance=None, configuration=None):
+    if sequance is None:
+        sequance = [1, 0, 1, 1]
+
+    vector = Vector(sequance)
+
+    if configuration is not None:
+        vector.set_configuration(configuration)
+
+    return vector
+
+
+def test_clean_configuration_empties_list():
+    vector = make_vector()
+    assert vector.configuration != []
+
+    vector.clean_configuration()
+
+    assert vector.configuration == []
+
+
+def test_update_space_configuration_counter_matches_compute():
+    vector = make_vector(configuration=[complex(1, 0), complex(0, 1), complex(1, 0)])
+
+    vector.update_space_configuration_counter()
+
+    assert vector.space_configuration_counter == Counter(vector.space_configuration)
+
+
+def test_check_space_configuration_counter_true_when_no_collision():
+    vector = make_vector(sequance=[1, 0, 1], configuration=[complex(1, 0), complex(0, 1)])
+
+    assert vector.check_space_configuration_counter(complex(0, 1), 0) is True
+
+
+def test_check_space_configuration_counter_false_when_collision():
+    vector = make_vector(sequance=[1, 0, 1], configuration=[complex(1, 0), complex(0, 1)])
+
+    assert vector.check_space_configuration_counter(complex(-1, 0), 0) is False
+
+
+def test_print_config_handles_all_directions_and_default():
+    vector = make_vector()
+
+    assert vector.print_config(complex(1, 0)) == "1"
+    assert vector.print_config(complex(-1, 0)) == "-1"
+    assert vector.print_config(complex(0, 1)) == "i"
+    assert vector.print_config(complex(0, -1)) == "-i"
+    assert vector.print_config(complex(2, 2)) == ""
+
+
+def test_check_valid_of_configuration_true_when_no_overlap():
+    vector = make_vector()
+    vector.space_configuration = [complex(0, 0), complex(1, 0), complex(1, 1)]
+
+    assert vector.check_valid_of_configuration() is True
+
+
+def test_check_valid_of_configuration_false_when_overlap():
+    vector = make_vector()
+    vector.space_configuration = [complex(0, 0), complex(1, 0), complex(0, 0)]
+
+    assert vector.check_valid_of_configuration() is False
+
+
+def test_check_valid_configuration_returns_false_on_overlap():
+    vector = make_vector(sequance=[1, 0, 1], configuration=[complex(1, 0), complex(-1, 0)])
+
+    assert vector.check_valid_configuration() is False
+
+
+def test_set_configuration_at_index_appends_when_out_of_range():
+    vector = make_vector(sequance=[1, 0], configuration=[])
+
+    vector.set_configuration_at_index(0, complex(1, 0))
+
+    assert vector.configuration == [complex(1, 0)]
+
+
+def test_set_configuration_at_index_overwrites_when_in_range():
+    vector = make_vector(sequance=[1, 0, 1], configuration=[complex(1, 0), complex(0, 1)])
+
+    vector.set_configuration_at_index(1, complex(-1, 0))
+
+    assert vector.configuration == [complex(1, 0), complex(-1, 0)]
+
+
+def test_get_configuration_at_index_returns_value():
+    vector = make_vector(configuration=[complex(1, 0), complex(0, 1)])
+
+    assert vector.get_configuration_at_index(1) == complex(0, 1)
+
+
+def test_multiply_configuration_scales_from_index():
+    vector = make_vector(configuration=[complex(1, 0), complex(0, 1), complex(1, 0)])
+
+    vector.multiply_configuration(complex(-1, 0), index=1)
+
+    assert vector.configuration == [complex(1, 0), complex(0, -1), complex(-1, 0)]
+
+
+def test_multiply_configuration_verbose_prints(capsys):
+    vector = make_vector(configuration=[complex(1, 0)])
+    vector.verbose = True
+
+    vector.multiply_configuration(complex(-1, 0))
+
+    out = capsys.readouterr().out
+    assert "Original configration" in out
+    assert "Updated configration" in out
+
+
+def test_optimize_sequance_trims_and_extends_configuration():
+    vector = make_vector(sequance=[0, 1, 1, 0])
+    original_len = len(vector.configuration)
+
+    result = vector.optimize_sequance()
+
+    assert result == [1, 1]
+    assert vector.sequance == [1, 1]
+    assert len(vector.configuration) == original_len + (len(result) - 1)
+
+
+def test_get_space_configuration_set_returns_counter():
+    vector = make_vector(configuration=[complex(1, 0)])
+    vector.update_space_configuration_counter()
+
+    assert vector.get_space_configuration_set() == vector.space_configuration_counter
+
+
+def test_get_space_configuration_computes_when_empty():
+    vector = make_vector(sequance=[1, 0, 1], configuration=[complex(1, 0), complex(0, 1)])
+    vector.space_configuration = []
+
+    result = vector.get_space_configuration(index=1)
+
+    assert result == [complex(0, 0), complex(1, 0)]
+
+
+def test_get_space_configuration_returns_full_when_index_none():
+    vector = make_vector(configuration=[complex(1, 0), complex(0, 1)])
+    vector.compute_space_configuration()
+
+    result = vector.get_space_configuration()
+
+    assert result == vector.space_configuration
+
+
+def test_get_axis_covers_min_and_max_expansion_in_all_directions():
+    vector = make_vector()
+    vector.space_configuration = [complex(-2, 0), complex(3, 0), complex(0, -3), complex(0, 4)]
+
+    axis = vector.get_axis()
+
+    assert axis == (-3, 4, -4, 5)
+
+
+def test_compute_space_configuration_stops_at_index():
+    vector = make_vector(sequance=[1, 0, 1, 1], configuration=[complex(1, 0), complex(0, 1), complex(1, 0)])
+
+    result = vector.compute_space_configuration(1)
+
+    assert result == [complex(0, 0), complex(1, 0), complex(1, 1)]
+
+
+def test_compute_space_configuration_verbose_prints(capsys):
+    vector = make_vector(configuration=[complex(1, 0)])
+    vector.verbose = True
+
+    vector.compute_space_configuration()
+
+    assert "Space configuration" in capsys.readouterr().out
+
+
+def test_compute_free_energy_uses_given_space_config():
+    vector = make_vector(sequance=[1, 1], configuration=[complex(1, 0)])
+    space_conf = [complex(0, 0), complex(1, 0)]
+
+    energy = vector.compute_free_energy(index=0, space_config=space_conf)
+
+    assert energy == 1.0
+
+
+def test_compute_free_energy_defaults_to_full_sequance():
+    vector = make_vector(sequance=[1, 1], configuration=[complex(1, 0)])
+
+    energy = vector.compute_free_energy()
+
+    assert energy == 1.0
+
+
+def test_compute_free_energy_verbose_prints(capsys):
+    vector = make_vector(sequance=[1, 1], configuration=[complex(1, 0)])
+    vector.verbose = True
+
+    vector.compute_free_energy()
+
+    assert "Free energy" in capsys.readouterr().out
+
+
+def test_update_free_energy_adds_distance_to_new_point():
+    vector = make_vector(sequance=[1, 1, 1, 1], configuration=[complex(1, 0), complex(1, 0), complex(1, 0)])
+    space_conf = [complex(0, 0), complex(1, 0), complex(2, 0), complex(3, 0)]
+
+    result = vector.update_free_energy(old_free_energy=5.0, index=3, space_conf=space_conf)
+
+    assert result == 7.0
+
+
+def test_eq_compares_sequance_elementwise():
+    vector_a = make_vector(sequance=[1, 0, 1])
+    vector_b = make_vector(sequance=[1, 0, 1])
+    vector_c = make_vector(sequance=[1, 1, 1])
+
+    assert vector_a == vector_b
+    assert not (vector_a == vector_c)
+
+
+def test_save_config_to_file_writes_png(tmp_path):
+    vector = make_vector(sequance=[1, 0, 1, 1], configuration=[complex(1, 0), complex(0, 1), complex(1, 0)])
+    output_path = tmp_path / "plot"
+
+    vector.save_config_to_file(str(output_path))
+
+    assert (tmp_path / "plot.png").exists()
+
+
+def test_plot_config_runs_with_and_without_index(monkeypatch):
+    vector = make_vector(sequance=[1, 0, 1, 1], configuration=[complex(1, 0), complex(0, 1), complex(1, 0)])
+    monkeypatch.setattr("matplotlib.pyplot.show", lambda: None)
+
+    vector.plot_config(index=1)
+    vector.plot_config()


### PR DESCRIPTION
## File covered
`data/vector.py`

## Coverage
- Before: 46.2% (161/299 lines uncovered, per SonarCloud)
- After (local `pytest --cov=data.vector --cov-report=term-missing`, full suite): 83% (51/299 lines uncovered, all remaining in the `if __name__ == "__main__":` demo block, which isn't reachable from unit tests)

## Bug fix (blocked writing a test otherwise)
`check_space_configuration_counter` called `self.compute_space_configuration_to_index(index)`, a method that does not exist anywhere in the codebase — every call raised `AttributeError`, and nothing else in the repo calls this method, so it was silently dead code. Fixed it to call the existing `compute_space_configuration(index)`, which matches the method's intended semantics (compute the space configuration up to `index`, then check whether moving `direction` from the last point collides with an already-occupied cell). No other behavior changed.

## What the new tests exercise
- `clean_configuration`, `set_configuration_at_index` (both branches), `get_configuration_at_index`
- `update_space_configuration_counter`, `get_space_configuration_set`, `get_space_configuration` (both branches)
- `check_space_configuration_counter` (collision / no-collision), now that the bug above is fixed
- `print_config` (all direction branches + default)
- `check_valid_of_configuration` / `check_valid_configuration` (valid + overlapping cases)
- `multiply_configuration` (scaling + verbose logging)
- `optimize_sequance` (trims sequence and extends configuration)
- `get_axis` (min/max expansion in all four directions)
- `compute_space_configuration` (index-bounded + verbose logging)
- `compute_free_energy` (explicit `space_config`, default full-sequence path, verbose logging)
- `update_free_energy`
- `__eq__`
- `save_config_to_file` (writes a real PNG to a tmp path) and `plot_config` (with/without index, `plt.show` monkeypatched to avoid blocking)

Full suite: 57 passed, 0 failed.

## Summary by Sourcery

Increase test coverage for data/vector.py and correct a misdirected space configuration computation call.

Bug Fixes:
- Fix check_space_configuration_counter to use the existing compute_space_configuration method instead of a non-existent compute_space_configuration_to_index.

Tests:
- Add comprehensive unit tests for Vector covering configuration management, space configuration computation and validation, axis and free energy calculations, sequence optimization, equality comparison, and plotting/output behaviors.