### PR TITLE
Extend tests for gen_algo/ant_colony.py (coverage 53.3% -> 100%)

### DIFF
--- a/tests/test_ant_colony.py
+++ b/tests/test_ant_colony.py
@@ -1,7 +1,7 @@
 from multiprocessing.dummy import Pool as ThreadPool
 
 from data.individual import Individual
-from gen_algo.ant_colony import AntColony
+from gen_algo.ant_colony import AntColony, EVAPORATE_CONSTANT, LEFT, RIGHT, STRAIGHT
 
 
 def make_ant_colony():
@@ -117,3 +117,130 @@ def test_local_search_drops_individuals_local_search_could_not_improve(monkeypat
     assert results == []
     assert individuals == []
     assert updated_tabu_lists == []
+
+
+def test_init_ants_resets_list():
+    colony = make_ant_colony()
+    colony.ants = ["stub"]
+
+    colony.init_ants()
+
+    assert colony.ants == []
+
+
+def test_update_heuristic_pheronome_value_covers_all_bands():
+    colony = make_ant_colony()
+
+    assert colony.update_heuristic_pheronome_value(0, 10) == (10, 1)
+    assert colony.update_heuristic_pheronome_value(3, 10) == (6, 3)
+    assert colony.update_heuristic_pheronome_value(5, 10) == (5, 4)
+    assert colony.update_heuristic_pheronome_value(9, 10) == (4, 4)
+
+
+def test_check_valid_of_new_individual_branches():
+    colony = make_ant_colony()
+
+    assert colony.check_valid_of_new_individual(None) is False
+    assert colony.check_valid_of_new_individual("something") is True
+
+
+def test_check_valid_of_new_individuals_branches():
+    colony = make_ant_colony()
+
+    assert colony.check_valid_of_new_individuals([None, None]) is False
+    assert colony.check_valid_of_new_individuals([None, "x"]) is True
+
+
+def test_search_orchestrates_ants_local_search_and_pheronome_update(monkeypatch):
+    colony = make_ant_colony()
+    colony.verbose = True
+
+    class FakeAnt:
+        def __init__(self, ant_index, sequance, pheronome, heuristic_val, pheronome_val):
+            self.ant_index = ant_index
+
+        def start(self):
+            pass
+
+        def join(self):
+            pass
+
+        def get_individual(self):
+            return "individual-%d" % self.ant_index
+
+        def get_tabu_list(self):
+            return [self.ant_index]
+
+    monkeypatch.setattr("gen_algo.ant_colony.Ant", FakeAnt)
+    monkeypatch.setattr(colony, "local_search", lambda individuals, tabu_lists: (individuals, tabu_lists))
+
+    recorded = {}
+
+    def fake_update(new_individuals, tabu_lists):
+        recorded["individuals"] = new_individuals
+        recorded["tabu_lists"] = tabu_lists
+
+    monkeypatch.setattr(colony, "update_pheronome_trails", fake_update)
+
+    results = colony.search()
+
+    assert results == ["individual-0", "individual-1"]
+    assert len(colony.ants) == 2
+    assert recorded["individuals"] == ["individual-0", "individual-1"]
+    assert recorded["tabu_lists"] == [[0], [1]]
+
+
+def test_update_pheronome_trails_applies_evaporation_and_delta(monkeypatch):
+    colony = make_ant_colony()
+    colony.verbose = True
+    colony.pheronome = [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]]
+
+    monkeypatch.setattr(
+        colony,
+        "compute_delta_pheronome",
+        lambda individuals, tabu_lists: [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+    )
+
+    colony.update_pheronome_trails([], [])
+
+    assert colony.pheronome[0] == [1.0, 1.0, 1.0]
+    assert colony.pheronome[1] == [
+        2.0 * EVAPORATE_CONSTANT + 0.1,
+        2.0 * EVAPORATE_CONSTANT + 0.2,
+        2.0 * EVAPORATE_CONSTANT + 0.3,
+    ]
+    assert colony.pheronome[2] == [
+        3.0 * EVAPORATE_CONSTANT + 0.4,
+        3.0 * EVAPORATE_CONSTANT + 0.5,
+        3.0 * EVAPORATE_CONSTANT + 0.6,
+    ]
+
+
+def test_compute_delta_pheronome_accumulates_by_direction():
+    colony = make_ant_colony()
+    colony.verbose = True
+    colony.pheronome = [[0, 0, 0], [0, 0, 0]]
+
+    class FakeIndividual:
+        def __init__(self, free_energy):
+            self._free_energy = free_energy
+
+        def get_free_energy(self):
+            return self._free_energy
+
+    individuals = [FakeIndividual(10), FakeIndividual(20)]
+    tabu_lists = [[9, STRAIGHT], [9, LEFT]]
+
+    delta = colony.compute_delta_pheronome(individuals, tabu_lists)
+
+    assert delta == [[100.0, 50.0, 0.0]]
+
+
+def test_update_tabu_list_detects_turns_from_configuration():
+    colony = make_ant_colony()
+    individual = Individual([0, 1, 1, 0, 1])
+    individual.vector.set_configuration([complex(1, 0), complex(1, 0), complex(0, 1), complex(1, 0)])
+
+    tabu_list = colony.update_tabu_list(individual)
+
+    assert tabu_list == [STRAIGHT, STRAIGHT, LEFT, RIGHT]


### PR DESCRIPTION
## File covered
`gen_algo/ant_colony.py`

## Coverage
- Before: 53.3% (70/150 lines uncovered, per SonarCloud)
- After (local `pytest --cov=gen_algo.ant_colony --cov-report=term-missing`, full suite): 100%

## What the new tests exercise (added to tests/test_ant_colony.py)
- `init_ants` resets the ants list
- `update_heuristic_pheronome_value` across all four iteration bands
- `check_valid_of_new_individual` / `check_valid_of_new_individuals` (both branches each)
- `search`: full orchestration — spawns ants (via a lightweight `Ant` stub so the test doesn't spin up real threads/searches), collects individuals/tabu lists, calls `local_search` and `update_pheronome_trails`
- `update_pheronome_trails`: evaporation + delta applied per-direction, index 0 left untouched
- `compute_delta_pheronome`: accumulates `DELTA_PHERONOME_CONSTANT / free_energy` into the matching direction slot and 0 elsewhere, using a fake individual to control free energy deterministically
- `update_tabu_list`: builds a configuration that goes straight, then turns left, then turns right, and checks the derived tabu list matches (`[STRAIGHT, STRAIGHT, LEFT, RIGHT]`)

No source changes — only test additions. Full suite: 38 passed, 0 failed.

## Summary by Sourcery

Extend test coverage for the ant colony genetic algorithm implementation to fully exercise core behaviors and orchestration logic.

Tests:
- Add tests covering ant initialization, heuristic pheromone band calculations, and validity checks for new individuals.
- Add integration-style test for the search routine to verify ant spawning, result collection, local search invocation, and pheromone trail updates.
- Add tests for pheromone trail updates including evaporation, delta application per direction, and delta computation based on free energy and tabu paths.
- Add test ensuring tabu list generation correctly detects straight moves and left/right turns from individual configurations.