### PR TITLE
Document the PR-cleanup loop workflow in github-pr-maintenance skill

### DIFF
--- a/.claude/skills/github-pr-maintenance/SKILL.md
+++ b/.claude/skills/github-pr-maintenance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-pr-maintenance
-description: "Use this skill whenever asked to check on, monitor, or fix open pull requests for this repo (kejhy93/ProteinFolding) — CI status, review comments, merge conflicts, or a batch of PRs at once. Triggers include 'check my PRs', 'are the PRs green', 'check for merge conflicts', 'reply to PR comments', 'why is this PR failing'. Wraps the scripts in scripts/github/ and documents recurring failure patterns specific to this repo's CI setup, discovered while managing ~90 sonar/* cleanup PRs in one session."
+description: "Use this skill whenever asked to check on, monitor, fix, or clean up open pull requests for this repo (kejhy93/ProteinFolding) — CI status, review comments, merge conflicts, or a batch of PRs at once. Triggers include 'check my PRs', 'are the PRs green', 'check for merge conflicts', 'reply to PR comments', 'why is this PR failing', 'fix the review comments', 'resolve PR feedback', 'get all PRs clean/green', or a recurring goal to keep PRs clean. Wraps the scripts in scripts/github/, documents recurring failure patterns specific to this repo's CI setup, and gives a loop procedure for driving every open PR to zero unresolved comments and all-green checks — discovered while managing ~90 sonar/* cleanup PRs in one session and while closing out a batch of test-coverage PRs in another."
 ---
 
 # GitHub PR Maintenance
@@ -31,6 +31,67 @@ repo/owner defaults and edge cases:
 
 All four take an optional `repo` argument; they default to the current
 directory's `gh repo view` remote (`kejhy93/ProteinFolding`).
+
+## Driving every open PR to a clean state (loop until no unresolved comments + all CI green)
+
+Use this procedure whenever the ask is to get PRs "clean," "green," free of
+unresolved comments, or is a recurring goal ("check every 20 minutes until
+everything's clean") rather than a one-off status check.
+
+1. `pr-sweep.sh` for the overview of every open PR.
+2. For each PR with a failing/pending check or outstanding comments, run
+   `pr-detail.sh <PR>` **before** touching anything — know why it's failing
+   or what's being asked for, don't guess.
+3. Fix on that PR's own branch (`git checkout <branch>`) — commit, push.
+   Pushing kicks off a fresh CI run that supersedes the failing one; don't
+   wait on the old run's result.
+4. Reply to the thread summarizing what changed (reference the commit), then
+   resolve it via the GraphQL mutation above — `gh pr comment` alone does
+   **not** resolve a review thread.
+5. After pushing, re-check that PR's CI (`gh pr checks <PR> --watch` or a
+   fresh `pr-detail.sh <PR>`) before moving to the next PR.
+6. Re-run `pr-sweep.sh` once more at the end of the batch, not just once at
+   the start — a merge or a new bot comment can land mid-session (see the
+   "sibling sonar/* PRs" pattern below), and "sweep once, fix everything,
+   done" will miss that.
+
+If working through several PRs from the same batch/session/goal, track them
+as a short task list (one task per PR) rather than holding the list in your
+head — it survives a context compaction, and it's the only way to be sure
+the final sweep actually covered every PR you touched.
+
+**`pr-sweep.sh`'s comment count is not the same as "unresolved."** The
+`Review comments not authored by the repo owner` line is a raw count from
+the REST API — it does not decrease when a thread is resolved, so it stays
+nonzero forever on any PR that ever got bot feedback, clean or not. To check
+what's actually still open, query GraphQL and filter on `isResolved`:
+```bash
+gh api graphql -f query='
+query { repository(owner:"OWNER", name:"REPO") { pullRequest(number: PR) {
+  reviewThreads(first: 20) { nodes { isResolved } }
+}}}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)'
+```
+Empty output means fully resolved regardless of what the sweep count shows.
+
+**Verify a bot's suggested code before applying it — don't paste it in
+blind.** Sourcery (and similar reviewers) sometimes proposes a "suggested
+implementation" that's wrong for the actual code under review — e.g. it once
+suggested a test asserting `compute_probability_of_next_move(...,
+free_energy=[0, 0])` returns `NO_ROUTE`, but the real implementation divides
+by `free_energy_val` and raises `ZeroDivisionError` on exactly that input.
+Before writing the suggested code, or replying "done," actually run it — a
+quick `python3 -c "..."` against the real class/function is enough to know
+which of these applies:
+- Correct as-is → apply it.
+- Right intent, wrong details (bad data shape, wrong index, wrong expected
+  value) → keep the intent, fix the implementation against real behavior,
+  and verify your version actually passes before pushing.
+- Based on a false premise about what the code does → don't write a test
+  asserting the wrong thing just to make the thread go away. Reply with the
+  concrete evidence (the exception/output you got) explaining the actual
+  behavior. If there's a real bug underneath the false premise, treat fixing
+  it as its own decision — scope it deliberately, don't smuggle it in as a
+  side effect of satisfying the comment.
 
 ## Known recurring patterns (from managing ~90 sonar/* PRs)
 


### PR DESCRIPTION
Generalizes the sweep-fix-reply-resolve-reverify loop used to drive open PRs to zero unresolved comments and all-green CI, plus two gotchas hit along the way: pr-sweep.sh's comment count doesn't reflect thread resolution, and bot-suggested review fixes should be run before being trusted.

## Summary by Sourcery

Document a repeatable workflow for driving all open PRs to a clean state with zero unresolved comments and all-green CI in the github-pr-maintenance skill.

Documentation:
- Expand the skill description to cover ongoing PR cleanup goals and the documented loop for resolving comments and getting checks green.
- Add a detailed procedure for iterating over open PRs, fixing issues, resolving review threads, and re-sweeping to catch late-arriving changes.
- Document limitations of pr-sweep.sh’s comment counts versus actual unresolved review threads and how to check resolution via GraphQL.
- Add guidance on safely handling bot-suggested code changes, including verifying suggestions against real behavior before applying or responding.