### PR TITLE
Add tests for script.py (coverage 0% -> 100%)

### DIFF
--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,81 @@
+import os
+import runpy
+
+SCRIPT_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "script.py")
+
+
+class FakeVector:
+    def __init__(self, free_energy):
+        self._free_energy = free_energy
+        self.plotted = False
+
+    def compute_free_energy(self):
+        return self._free_energy
+
+    def plot_config(self):
+        self.plotted = True
+
+
+class FakeGeneticsAlgorithm:
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        FakeGeneticsAlgorithm.instances.append(args)
+        self._result = FakeVector(42.0)
+
+    def solve(self):
+        return self._result
+
+
+def write_testsuite(tmp_path):
+    # First line: 0 hydrophobic residues -> takes the "skip GA" branch.
+    # Second line: 15 hydrophobic residues -> takes the "run GA" branch.
+    testsuite = tmp_path / "testsuite.txt"
+    testsuite.write_text("00000\n" + "1" * 15 + "\n")
+    return testsuite
+
+
+def test_script_runs_pipeline_skips_short_sequences_and_solves_long_ones(monkeypatch, tmp_path, capsys):
+    write_testsuite(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    FakeGeneticsAlgorithm.instances = []
+    monkeypatch.setattr("gen_algo.genetics_algorithm.GeneticsAlgorithm", FakeGeneticsAlgorithm)
+
+    appended = []
+    monkeypatch.setattr(
+        "utils.append_to_file",
+        lambda configuration, free_energy, index: appended.append((free_energy, index)),
+    )
+    monkeypatch.setattr("utils.read_minimal_energy_from_file", lambda protein_id: None)
+
+    runpy.run_path(SCRIPT_PATH, run_name="__main__")
+
+    out = capsys.readouterr().out
+
+    # Only the 15-hydrophobic-residue sequence should have gone through the GA solver.
+    assert len(FakeGeneticsAlgorithm.instances) == 1
+    assert FakeGeneticsAlgorithm.instances[0][0] == [1] * 15
+
+    # append_to_file is only called for the GA-solved sequence, with its free energy.
+    assert appended == [(42.0, 1)]
+
+    assert "Current optimum:     -1.000" in out
+    assert "Total score:  21.0" in out
+    assert "Final Result:" in out
+
+
+def test_script_reports_existing_optimum_from_history_file(monkeypatch, tmp_path, capsys):
+    write_testsuite(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    FakeGeneticsAlgorithm.instances = []
+    monkeypatch.setattr("gen_algo.genetics_algorithm.GeneticsAlgorithm", FakeGeneticsAlgorithm)
+    monkeypatch.setattr("utils.append_to_file", lambda configuration, free_energy, index: None)
+    monkeypatch.setattr("utils.read_minimal_energy_from_file", lambda protein_id: 7.5)
+
+    runpy.run_path(SCRIPT_PATH, run_name="__main__")
+
+    out = capsys.readouterr().out
+
+    assert "Current optimum:      7.500" in out

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -60,9 +60,10 @@ def test_script_runs_pipeline_skips_short_sequences_and_solves_long_ones(monkeyp
     # append_to_file is only called for the GA-solved sequence, with its free energy.
     assert appended == [(42.0, 1)]
 
-    assert "Current optimum:     -1.000" in out
-    assert "Total score:  21.0" in out
-    assert "Final Result:" in out
+    normalized_out = " ".join(out.split())
+    assert "Current optimum: -1.000" in normalized_out
+    assert "Total score: 21.0" in normalized_out
+    assert "Final Result:" in normalized_out
 
 
 def test_script_reports_existing_optimum_from_history_file(monkeypatch, tmp_path, capsys):
@@ -78,4 +79,5 @@ def test_script_reports_existing_optimum_from_history_file(monkeypatch, tmp_path
 
     out = capsys.readouterr().out
 
-    assert "Current optimum:      7.500" in out
+    normalized_out = " ".join(out.split())
+    assert "Current optimum: 7.500" in normalized_out


### PR DESCRIPTION
## File covered
`script.py`

## Coverage
- Before: 0.0% (46/46 lines uncovered, per SonarCloud) — the whole file lives inside `if __name__ == "__main__":`
- After (local `pytest --cov=script --cov-report=term-missing`, full suite): 100%

## Approach
`script.py` is a top-level entry-point script, not a module of importable functions — every statement lives under the `__main__` guard. To cover it without turning this into an end-to-end integration test (a real `GeneticsAlgorithm.solve()` run is slow and non-deterministic, and `utils.append_to_file` writes to a real `result/` folder relative to cwd), the tests:
- Run the script via `runpy.run_path(..., run_name="__main__")` from a temp cwd (`tmp_path`), with a small `testsuite.txt` written there so the repo's real `testsuite.txt`/`result/` are never touched.
- Fake out `gen_algo.genetics_algorithm.GeneticsAlgorithm` (script.py's own collaborator — already covered on its own terms in `tests/test_genetics_algorithm.py`) so the test exercises script.py's *own* orchestration logic: branch selection, score aggregation, file-writing calls, print output.
- Fake `utils.append_to_file` / `utils.read_minimal_energy_from_file` to assert on what script.py actually passes them, without real file I/O.

## What the new tests exercise
- The `if not modify_sequance or protein.get_count_of_hydro() <= 10:` skip branch (a 0-hydrophobic sequence bypasses the GA solve) vs. the GA-solve branch (a 15-hydrophobic sequence goes through `GeneticsAlgorithm(...).solve()`), verified by asserting the fake solver was constructed exactly once with the expected sequence.
- `total_score` accumulation and the final "Total score" / "Final Result" print lines.
- `append_to_file` called only for the GA-solved sequence, with its free energy and index.
- The `free_energy_from_file == None` fallback to `-1` vs. reporting a real previously-recorded optimum, verified via the printed "Current optimum" line in both scenarios.

No source changes — only test additions. Full suite: 93 passed, 0 failed.

## Summary by Sourcery

Add unit tests to fully exercise the script.py entry-point pipeline, achieving complete coverage of its main execution flow.

Tests:
- Add tests that run script.py via runpy from a temporary working directory to cover its orchestration logic without real side effects.
- Verify branch behavior between skipping short hydrophobic sequences and solving longer ones via the genetics algorithm collaborator.
- Assert correct aggregation of total score, final output lines, and interactions with history file helpers for both missing and existing optima.