### PR TITLE
Add tests for data/population.py (coverage 67.0% -> 93%)

### DIFF
--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -1,0 +1,63 @@
+from data.population import Population
+from data.vector import Vector
+
+
+class FakeIndividual:
+    def __init__(self, free_energy):
+        self._free_energy = free_energy
+
+    def get_free_energy(self):
+        return self._free_energy
+
+
+def test_init_population_verbose_prints(capsys):
+    population = Population(2)
+    population.verbose = True
+    vector = Vector([0, 1, 1, 0])
+
+    population.init_population(vector)
+
+    assert "Init of population" in capsys.readouterr().out
+    assert population.count_of_individuals() == 2
+
+
+def test_exist_lower_value_in_finds_first_lower_value():
+    population = Population(1)
+
+    assert population.exist_lower_value_in(5, [10, 3, 8]) == (True, 1)
+
+
+def test_exist_lower_value_in_returns_false_when_none_lower():
+    population = Population(1)
+
+    assert population.exist_lower_value_in(5, [10, 8, 6]) == (False, -1)
+
+
+def test_move_shifts_and_inserts():
+    population = Population(1)
+
+    new_index, new_values = population.move([0, 1, 2], [10, 20, 30], 1, 99, 15)
+
+    assert new_values == [10, 15, 20]
+    assert new_index == [0, 99, 1]
+
+
+def test_find_worst_individuals_tracks_highest_energy_individuals():
+    population = Population(5)
+    population.individuals = [FakeIndividual(e) for e in [5, 100, 50, 200, 10]]
+
+    worst = population.find_worst_individuals(2)
+
+    assert worst == [3, 1]
+
+
+def test_str_prints_verbose_message_and_lists_individuals(capsys):
+    population = Population(1)
+    population.verbose = True
+    population.individuals = [FakeIndividual(5)]
+
+    result = str(population)
+
+    out = capsys.readouterr().out
+    assert "Print population" in out
+    assert "Individual 1:" in result


### PR DESCRIPTION
## File covered
`data/population.py`

## Coverage
- Before: 67.0% (31/94 lines uncovered, per SonarCloud)
- After (local `pytest --cov=data.population --cov-report=term-missing`, full suite): 93% — remaining 7 lines are the `if __name__ == "__main__":` demo block, unreachable from unit tests.

## What the new tests exercise
- `init_population`'s verbose logging
- `exist_lower_value_in` (found / not-found branches)
- `move` (shift-and-insert into a fixed-size tracking list), verified against hand-computed expected output
- `find_worst_individuals`: populated `Population.individuals` directly with fake individuals of known free energies and verified it returns the indices of the two highest-energy individuals in worst-first order — exercising the `exist_lower_value_in`/`move` interaction end to end
- `__str__`'s verbose logging and individual listing

`pick_random_individual`, `generate_candidate_list`, `find_best_individual`, `set_individual_at`, `get_individual_at`, and `pick_best_individual` were already covered by other test files (`tests/test_genetics_algorithm.py` etc.) — full-suite coverage confirms this, so no tests were duplicated for those.

No source changes — only test additions. Full suite: 97 passed, 0 failed.

## Summary by Sourcery

Add new unit tests for the Population class to significantly increase coverage of data/population.py.

Tests:
- Add tests for verbose initialization logging of Population.init_population.
- Add tests covering exist_lower_value_in for both found and not-found cases.
- Add tests verifying move correctly shifts indices and inserts new values into tracking lists.
- Add tests for find_worst_individuals to ensure it identifies and orders the highest-energy individuals as expected.
- Add tests for Population.__str__ to validate verbose output and individual listing.