### PR TITLE
Add tests for visualize_protein_history.py (coverage 0% -> 67%)

### DIFF
--- a/tests/test_visualize_protein_history.py
+++ b/tests/test_visualize_protein_history.py
@@ -1,0 +1,62 @@
+import os
+
+import utils
+import visualize_protein_history as vph
+from data.data import Data
+from data.vector import Vector
+
+
+class FakeVector:
+    def __init__(self, label):
+        self.label = label
+        self.saved_to = None
+
+    def save_config_to_file(self, filename):
+        self.saved_to = filename
+
+
+def test_visualize_creates_folder_and_saves_each_history_entry(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(vph, "CONFIGURATION_FOLDER", "configuration_diagram")
+
+    history = [FakeVector("a"), FakeVector("b")]
+
+    vph.visualize(history, 3)
+
+    config_folder = tmp_path / "configuration_diagram"
+    base_path = os.path.join("configuration_diagram", utils.create_filename(3))
+    assert config_folder.exists()
+    assert history[0].saved_to == base_path + "-001"
+    assert history[1].saved_to == base_path + "-002"
+
+
+def test_visualize_skips_makedirs_when_folder_already_exists(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(vph, "CONFIGURATION_FOLDER", "configuration_diagram")
+    (tmp_path / "configuration_diagram").mkdir()
+
+    vph.visualize([], 1)
+
+    assert (tmp_path / "configuration_diagram").exists()
+
+
+def test_read_history_of_configuration_of_returns_empty_when_file_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(vph, "protein", Data([1, 0, 1], 0), raising=False)
+
+    result = vph.read_history_of_configuration_of(str(tmp_path / "missing.txt"))
+
+    assert result == []
+
+
+def test_read_history_of_configuration_of_reads_real_history_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(vph, "protein", Data([1, 0, 1], 0), raising=False)
+
+    vector = Vector([1, 0, 1])
+    vector.set_configuration([complex(1, 0), complex(0, 1)])
+    history_file = tmp_path / "history.txt"
+    history_file.write_text("5.0 " + str(vector.get_configuration()))
+
+    result = vph.read_history_of_configuration_of(str(history_file))
+
+    assert len(result) == 1
+    assert result[0].get_configuration() == [complex(1, 0), complex(0, 1)]


### PR DESCRIPTION
## File covered
`visualize_protein_history.py`

## Coverage
- Before: 0.0% (30/30 lines uncovered, per SonarCloud) — module was never imported by the test suite
- After (local `pytest --cov=visualize_protein_history --cov-report=term-missing`, full suite): 67% — remaining 10 lines are the `if __name__ == "__main__":` script block, unreachable from unit tests.

## What the new tests exercise
- `visualize()`: creates `CONFIGURATION_FOLDER` when missing and calls `save_config_to_file` on each history entry with the expected per-entry filename, and is a no-op-safe when the folder already exists
- `read_history_of_configuration_of()`: note this function reads a **module-level global** `protein` (set by the `for protein in set_of_all_proteins:` loop in `__main__`, not a parameter) rather than taking the protein as an argument. That's existing behavior, not something this PR changes — the tests set `visualize_protein_history.protein` via `monkeypatch.setattr(..., raising=False)` to match how it's actually invoked, then verify the empty-result case (missing file) and a real round-trip through `utils.read_configuration_history` (missing-file / found-file branches)

No source changes — only test additions. Full suite: 95 passed, 0 failed.

## Summary by Sourcery

Add unit tests for the visualize_protein_history module to exercise its main behaviors and significantly increase its code coverage.

Tests:
- Add tests for visualize() to ensure configuration folders are created or reused and history entries are saved with the expected filenames.
- Add tests for read_history_of_configuration_of() to verify behavior for missing history files and successful configuration history round-trips.