### PR TITLE
Extend tests for gen_algo/mutation.py (coverage 52.5% -> 100%)

### DIFF
--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -14,3 +14,127 @@ def test_do_mutation_mutates_individual():
     
     
     assert not (original_individual.__eq__ (mutated_individual))
+
+
+class FakeMutatedIndividual:
+    def __init__(self, free_energy, valid=True):
+        self._free_energy = free_energy
+        self._valid = valid
+
+    def compute_free_energy(self):
+        return self._free_energy
+
+    def check_valid_configuration(self):
+        return self._valid
+
+
+def test_mutate_one_point_flips_configs_below_mutation_rate(monkeypatch):
+    individual = Individual([0, 1, 1, 0])
+    original_config = list(individual.get_individual().get_configuration())
+
+    monkeypatch.setattr("gen_algo.mutation.random.random", lambda: 0.05)
+
+    mutated = mutate_one_point(individual, mutation_rate=0.1)
+
+    mutated_config = mutated.get_individual().get_configuration()
+    expected = [c * complex(0, 1) for c in original_config]
+    assert mutated_config == expected
+    assert mutated is not individual
+
+
+def test_mutate_from_point_flips_from_random_index_to_end(monkeypatch):
+    individual = Individual([0, 1, 1, 0, 1])
+    original_config = list(individual.get_individual().get_configuration())
+
+    monkeypatch.setattr("gen_algo.mutation.random.randint", lambda a, b: 1)
+
+    mutated = mutate_from_point(individual, mutation_rate=0.1)
+
+    mutated_config = mutated.get_individual().get_configuration()
+    expected = list(original_config)
+    for i in range(1, len(expected)):
+        expected[i] *= complex(0, 1)
+    assert mutated_config == expected
+
+
+def test_mutate_from_to_point_flips_range(monkeypatch):
+    individual = Individual([0, 1, 1, 0, 1, 0])
+    original_config = list(individual.get_individual().get_configuration())
+
+    calls = iter([1, 3])
+    monkeypatch.setattr("gen_algo.mutation.random.randint", lambda a, b: next(calls))
+
+    mutated = mutate_from_to_point(individual, mutation_rate=0.1)
+
+    mutated_config = mutated.get_individual().get_configuration()
+    expected = list(original_config)
+    for i in range(1, 3):
+        expected[i] *= complex(-1, 0)
+    assert mutated_config == expected
+
+
+def test_pick_mutation_method_without_iteration_info(monkeypatch):
+    monkeypatch.setattr("gen_algo.mutation.random.random", lambda: 0.4)
+    assert pick_mutation_method(None, None) is mutate_one_point
+
+    monkeypatch.setattr("gen_algo.mutation.random.random", lambda: 0.6)
+    assert pick_mutation_method(None, None) is mutate_from_point
+
+
+def test_pick_mutation_method_early_iteration(monkeypatch):
+    monkeypatch.setattr("gen_algo.mutation.random.random", lambda: 0.5)
+    assert pick_mutation_method(1, 10) is mutate_from_point
+
+    monkeypatch.setattr("gen_algo.mutation.random.random", lambda: 0.95)
+    assert pick_mutation_method(1, 10) is mutate_from_to_point
+
+
+def test_pick_mutation_method_late_iteration(monkeypatch):
+    monkeypatch.setattr("gen_algo.mutation.random.random", lambda: 0.5)
+    assert pick_mutation_method(9, 10) is mutate_one_point
+
+    monkeypatch.setattr("gen_algo.mutation.random.random", lambda: 0.95)
+    assert pick_mutation_method(9, 10) is mutate_from_to_point
+
+
+def test_do_mutation_verbose_prints(monkeypatch, capsys):
+    monkeypatch.setattr("gen_algo.mutation.verbose", True)
+    individual = Individual([0, 1, 1, 0])
+    monkeypatch.setattr(
+        "gen_algo.mutation.pick_mutation_method",
+        lambda iteration, max_iteration: (lambda ind, rate: deepcopy(ind)),
+    )
+
+    do_mutation(individual, mutation_rate=0.1, iteration=1, max_iteration=10)
+
+    assert "GeneticsAlgorithm -> Mutation" in capsys.readouterr().out
+
+
+def test_do_mutation_accepts_when_valid_and_improved(monkeypatch):
+    original = Individual([0, 1, 1, 0])
+    original.free_energy = 100.0
+
+    better = FakeMutatedIndividual(free_energy=5.0, valid=True)
+    monkeypatch.setattr(
+        "gen_algo.mutation.pick_mutation_method",
+        lambda iteration, max_iteration: (lambda ind, rate: better),
+    )
+
+    result = do_mutation(original, mutation_rate=0.1, iteration=1, max_iteration=10)
+
+    assert result is better
+
+
+def test_do_mutation_rejects_when_invalid(monkeypatch):
+    original = Individual([0, 1, 1, 0])
+    original.free_energy = 100.0
+
+    worse_but_invalid = FakeMutatedIndividual(free_energy=5.0, valid=False)
+    monkeypatch.setattr(
+        "gen_algo.mutation.pick_mutation_method",
+        lambda iteration, max_iteration: (lambda ind, rate: worse_but_invalid),
+    )
+
+    result = do_mutation(original, mutation_rate=0.1, iteration=1, max_iteration=10)
+
+    assert result is original

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -42,6 +42,19 @@ def test_mutate_one_point_flips_configs_below_mutation_rate(monkeypatch):
     assert mutated is not individual
 
 
+def test_mutate_one_point_leaves_configs_above_mutation_rate_unchanged(monkeypatch):
+    individual = Individual([0, 1, 1, 0])
+    original_config = list(individual.get_individual().get_configuration())
+
+    monkeypatch.setattr("gen_algo.mutation.random.random", lambda: 0.5)
+
+    mutated = mutate_one_point(individual, mutation_rate=0.1)
+
+    mutated_config = mutated.get_individual().get_configuration()
+    assert mutated_config == original_config
+    assert mutated is not individual
+
+
 def test_mutate_from_point_flips_from_random_index_to_end(monkeypatch):
     individual = Individual([0, 1, 1, 0, 1])
     original_config = list(individual.get_individual().get_configuration())


### PR DESCRIPTION
## File covered
`gen_algo/mutation.py`

## Coverage
- Before: 52.5% (29/61 lines uncovered, per SonarCloud)
- After (local `pytest --cov=gen_algo.mutation --cov-report=term-missing`, full suite): 100%

## What the new tests exercise (added to tests/test_mutation.py, alongside the existing test)
- `mutate_one_point`, `mutate_from_point`, `mutate_from_to_point`: each with `random.random`/`random.randint` pinned so the exact expected flipped configuration can be asserted precisely, rather than just checking "something changed"
- `pick_mutation_method`'s full branch matrix: no iteration info (50/50 one-point vs. from-point), early iteration (`iteration < MUTATION_TYPE * max_iteration`, 90/10 from-point vs. from-to-point), and late iteration (90/10 one-point vs. from-to-point)
- `do_mutation`'s verbose logging, and both the accept branch (valid + improved energy replaces the individual) and reject branch (invalid despite improved energy keeps the original) — using a fake mutated-individual so the free-energy comparison is deterministic rather than relying on real (random) mutation output

Note: the existing `test_do_mutation_mutates_individual` test asserts `not original.__eq__(mutated)`, but `Individual.__eq__` (`data/individual.py:66-74`) has a bug — it compares `self.get_individual` to `other.get_individual` (bound methods, missing `()`) rather than the underlying vectors, so that assertion is actually always true for any two distinct `Individual` instances regardless of whether mutation happened. Left as-is here (not this file, and the new tests below assert on real configuration/energy behavior instead) — flagging for the upcoming `data/individual.py` coverage PR, same as noted on #147.

No source changes — only test additions. Full suite: 100 passed, 0 failed.

## Summary by Sourcery

Expand test coverage for genetic algorithm mutation logic to fully exercise all mutation strategies, selection logic, and mutation outcomes.

Tests:
- Add deterministic tests for one-point, from-point, and from-to-point mutation functions to validate configuration changes.
- Cover all branches of pick_mutation_method, including behavior with and without iteration metadata.
- Add tests for do_mutation to verify verbose logging output and acceptance vs. rejection of mutated individuals based on validity and free-energy improvements.
- Introduce a FakeMutatedIndividual test double to control mutation outcomes and energy calculations in do_mutation tests.