### PR TITLE
Add tests for gen_algo/hill_climbing.py (coverage 28.6% -> 100%)

### DIFF
--- a/tests/test_hill_climbing.py
+++ b/tests/test_hill_climbing.py
@@ -1,0 +1,56 @@
+from gen_algo.hill_climbing import do_hill_climbing, hill_climbing
+
+
+class FakeIndividual:
+    def __init__(self, free_energy):
+        self.free_energy = free_energy
+
+    def get_free_energy(self):
+        return self.free_energy
+
+    def compute_free_energy(self):
+        return self.free_energy
+
+
+def test_do_hill_climbing_delegates_to_hill_climbing(monkeypatch):
+    individual = FakeIndividual(10)
+    monkeypatch.setattr(
+        "gen_algo.hill_climbing.do_mutation",
+        lambda ind: FakeIndividual(10),
+    )
+
+    result = do_hill_climbing(individual, count_of_iteration=3, count_of_neighbor=2)
+
+    assert result is individual
+
+
+def test_hill_climbing_terminates_immediately_when_no_improvement(monkeypatch):
+    call_count = {"n": 0}
+
+    def fake_do_mutation(individual):
+        call_count["n"] += 1
+        return FakeIndividual(individual.get_free_energy())
+
+    monkeypatch.setattr("gen_algo.hill_climbing.do_mutation", fake_do_mutation)
+
+    individual = FakeIndividual(10)
+    result = hill_climbing(individual, iteration=5, count_of_neighour=3)
+
+    assert result is individual
+    assert call_count["n"] == 3
+
+
+def test_hill_climbing_recurses_until_iteration_exhausted(monkeypatch):
+    call_count = {"n": 0}
+
+    def fake_do_mutation(individual):
+        call_count["n"] += 1
+        return FakeIndividual(individual.get_free_energy() - 1)
+
+    monkeypatch.setattr("gen_algo.hill_climbing.do_mutation", fake_do_mutation)
+
+    individual = FakeIndividual(10)
+    result = hill_climbing(individual, iteration=2, count_of_neighour=1)
+
+    assert call_count["n"] == 3
+    assert result.get_free_energy() == 9


### PR DESCRIPTION
## File covered
`gen_algo/hill_climbing.py`

## Coverage
- Before: 28.6% (15/21 lines uncovered, per SonarCloud)
- After (local `pytest --cov=gen_algo.hill_climbing --cov-report=term-missing`, full suite): 100%

## What the new tests exercise
- `do_hill_climbing()` delegates to `hill_climbing()`
- `hill_climbing()`'s termination via "no improvement in this neighbor pass" (`init_score == best_score`), with `do_mutation` faked and a call counter confirming it stops after exactly one pass despite a large `iteration` budget
- `hill_climbing()`'s recursive continuation: `do_mutation` faked to always report an improved score, driving the recursion down to `iteration == 0` and confirming the expected number of neighbor-generation calls and the final returned energy

Note: `hill_climbing`'s recursive call passes the original `individual` back in on each recursive call, not the improved `best_neighbor` found so far (`gen_algo/hill_climbing.py:41`) — so each recursion level re-explores neighbors of the same starting point rather than climbing from the best point found. That's existing behavior; the tests assert what the code actually does, not what "hill climbing" would ideally do. Flagging it here since it wasn't obvious without tracing the recursion, in case it's worth a closer look separately.

No source changes — only test additions. Full suite: 94 passed, 0 failed.

## Summary by Sourcery

Add tests to fully exercise gen_algo.hill_climbing.py and achieve 100% coverage for its hill climbing behavior.

Tests:
- Add unit tests for do_hill_climbing delegation to hill_climbing.
- Add tests covering hill_climbing termination when no neighbor improves the score.
- Add tests covering hill_climbing recursive behavior when neighbors consistently improve the score.