### PR TITLE
Add tests for abstract_solver.py (coverage 77.8% -> 100%)

### DIFF
--- a/tests/test_abstract_solver.py
+++ b/tests/test_abstract_solver.py
@@ -1,0 +1,25 @@
+from abstract_solver import AbstractSolver
+
+
+def test_init_stores_sequance_and_builds_result_vector():
+    solver = AbstractSolver([0, 1, 1, 0])
+
+    assert solver.sequance == [0, 1, 1, 0]
+    assert solver.result_vector.get_amino_sequance() == [0, 1, 1, 0]
+
+
+def test_solve_verbose_prints_message(capsys):
+    solver = AbstractSolver([0, 1, 1, 0])
+    solver.verbose = True
+
+    solver.solve()
+
+    assert "AbstractSolver -> solve" in capsys.readouterr().out
+
+
+def test_solve_silent_by_default(capsys):
+    solver = AbstractSolver([0, 1, 1, 0])
+
+    solver.solve()
+
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## File covered
`abstract_solver.py`

## Coverage
- Before: 77.8% (2/9 lines uncovered, per SonarCloud)
- After (local `pytest --cov=abstract_solver --cov-report=term-missing`, full suite): 100%

## What the new tests exercise
- `__init__` stores the sequence and builds the `result_vector`
- `solve()`'s verbose logging branch, and confirms it's silent by default

No source changes — only test additions. Full suite: 94 passed, 0 failed.

## Summary by Sourcery

Add unit tests to fully cover AbstractSolver initialization and verbose/quiet solving behavior.

Tests:
- Add tests verifying AbstractSolver stores the input sequence and initializes the result vector correctly.
- Add tests confirming solve() emits a log message in verbose mode and remains silent by default.