### PR TITLE
Improve github-pr-maintenance skill: unresolved threads and new-push detection

### DIFF
--- a/.claude/skills/github-pr-maintenance/SKILL.md
+++ b/.claude/skills/github-pr-maintenance/SKILL.md
@@ -11,8 +11,11 @@ Use these instead of hand-rolling `gh` one-liners — they already handle the
 repo/owner defaults and edge cases:
 
 - `scripts/github/pr-sweep.sh` — overview of every open PR: mergeability,
-  conflicts, failing/pending checks, outstanding review-comment counts. Run
-  this first for any "check my PRs" style request.
+  conflicts, failing/pending checks, unresolved review-thread counts, and
+  which PRs have new commits pushed since their last review. Run this first
+  for any "check my PRs" style request, and also for "did anything get
+  pushed since the last review" style requests — the last section does that
+  comparison for every open PR in one pass.
 - `scripts/github/pr-detail.sh <PR>` — deep dive on one PR: full check list,
   SonarCloud quality gate + open issues for that PR's diff, open
   code-scanning alerts on its branch, review comments. Run this when a PR is
@@ -105,6 +108,34 @@ finding shows up and it's a direct, self-contained consequence of your own
 diff (not a second, independent SonarCloud issue from the backlog), fixing it
 in a follow-up commit is in scope — it isn't "bundling," it's finishing the
 original fix properly.
+
+**Raw inline-comment counts overstate what's outstanding — use thread
+resolution, not comment authorship.** A PR can have review comments from
+Sourcery while having zero *unresolved* threads, because Sourcery
+auto-resolves a thread once a follow-up commit matches its suggestion (see
+the `BLOCKED` pattern above). `pr-sweep.sh`'s "Unresolved review threads"
+section already does the right thing (GraphQL `isResolved`) — don't fall
+back to counting `pulls/<pr>/comments` by non-owner author, that count
+includes comments whose threads are long since resolved and will make clean
+PRs look like they need attention.
+
+**Detecting and reviewing new pushes since the last review.** For "did
+anything get pushed since I last reviewed" style requests: `pr-sweep.sh`'s
+"New commits since last review" section compares each PR's last commit
+(`commit.committer.date` from `pulls/<pr>/commits`) against its last actual
+review (`submitted_at` from `pulls/<pr>/reviews`) — deliberately *not*
+`pulls/<pr>/comments` or issue-timeline comments, which include CI status
+bots (`sonarqubecloud`, `github-actions`) that post *after* a real review and
+would mask a genuinely unreviewed push. For any PR it flags:
+1. List commits (`gh api repos/<repo>/pulls/<pr>/commits`) and find the ones
+   with a date after the last review's `submitted_at` — that's the new diff,
+   not the whole PR.
+2. Review only that slice: `git diff <last_reviewed_sha>..<head_sha> -- <path>`.
+3. Post findings with `gh pr review <pr> --comment --body "..."` —
+   **not** `--approve`. If the authenticated `gh` user is also the PR author
+   (true for this repo's own maintenance PRs), `--approve` fails outright
+   with `Can not approve your own pull request`. `--comment` works
+   regardless of authorship and is the right choice for self-authored PRs.
 
 **Sibling `sonar/*` PRs opened in the same batch will conflict once one
 merges, if they touch the same or adjacent lines.** Each PR in a batch is

--- a/.claude/skills/github-pr-maintenance/SKILL.md
+++ b/.claude/skills/github-pr-maintenance/SKILL.md
@@ -133,9 +133,9 @@ would mask a genuinely unreviewed push. For any PR it flags:
 2. Review only that slice: `git diff <last_reviewed_sha>..<head_sha> -- <path>`.
 3. Post findings with `gh pr review <pr> --comment --body "..."` —
    **not** `--approve`. If the authenticated `gh` user is also the PR author
-   (true for this repo's own maintenance PRs), `--approve` fails outright
-   with `Can not approve your own pull request`. `--comment` works
-   regardless of authorship and is the right choice for self-authored PRs.
++   (true for this repo's own maintenance PRs), `--approve` fails outright
++   with `Cannot approve your own pull request`. `--comment` works
++   regardless of authorship and is the right choice for self-authored PRs.
 
 **Sibling `sonar/*` PRs opened in the same batch will conflict once one
 merges, if they touch the same or adjacent lines.** Each PR in a batch is

--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -5,7 +5,9 @@ of open PRs (checks, conflicts, stale CI status, review comments). All
 scripts default `repo` to the current directory's git remote if omitted.
 
 - **pr-sweep.sh** — one-shot overview of every open PR: mergeability,
-  conflicts, failing/pending checks, and outstanding review-comment counts.
+  conflicts, failing/pending checks, unresolved review-thread counts (via
+  GraphQL `isResolved`, not raw comment counts), and which PRs have new
+  commits since their last review.
 - **pr-detail.sh `<PR>`** — deep dive on one PR: full check list, SonarCloud
   quality gate + open issues for that PR's diff, open code-scanning alerts on
   its branch, and review comments.

--- a/scripts/github/pr-sweep.sh
+++ b/scripts/github/pr-sweep.sh
@@ -42,9 +42,32 @@ for pr in $(gh pr list --repo "$REPO" --state open --limit 100 --json number --j
 done
 
 echo
-echo "== Review comments not authored by the repo owner =="
+echo "== Unresolved review threads =="
+# Raw inline-comment counts are misleading: Sourcery (and other bots) often
+# auto-resolve a thread once a follow-up commit matches their suggestion,
+# leaving the comment itself in place but no longer actionable. Query
+# isResolved via GraphQL instead of counting comments by non-owner authors.
 OWNER=$(gh repo view "$REPO" --json owner --jq .owner.login)
+REPO_OWNER="${REPO%%/*}"
+REPO_NAME="${REPO##*/}"
 for pr in $(gh pr list --repo "$REPO" --state open --limit 100 --json number --jq '.[].number'); do
-    count=$(gh api "repos/$REPO/pulls/$pr/comments" --jq "[.[] | select(.user.login != \"$OWNER\")] | length")
+    count=$(gh api graphql -f query='
+    query { repository(owner:"'"$REPO_OWNER"'", name:"'"$REPO_NAME"'") { pullRequest(number: '"$pr"') {
+      reviewThreads(first: 50) { nodes { isResolved } }
+    }}}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
     echo "PR $pr: $count"
+done
+
+echo
+echo "== New commits since last review =="
+# Compares the last commit's committer date against the last *review*
+# submission date (gh api .../reviews) — not issue/PR-level comments, which
+# include CI status bots (sonarqubecloud, github-actions) that post after
+# real reviews and would mask a genuinely unreviewed push.
+for pr in $(gh pr list --repo "$REPO" --state open --limit 100 --json number --jq '.[].number'); do
+    last_commit=$(gh api "repos/$REPO/pulls/$pr/commits" --jq '[.[].commit.committer.date] | sort | last // "1970-01-01T00:00:00Z"')
+    last_review=$(gh api "repos/$REPO/pulls/$pr/reviews" --jq '[.[].submitted_at] | sort | last // "1970-01-01T00:00:00Z"')
+    if [[ "$last_commit" > "$last_review" ]]; then
+        echo "PR $pr: NEW PUSH since last review (commit $last_commit > review $last_review)"
+    fi
 done


### PR DESCRIPTION
## Summary
- `pr-sweep.sh`'s "review comments" section now checks GraphQL `isResolved` per thread instead of counting raw comments by non-owner authors. The old count overstated what needed attention — Sourcery frequently auto-resolves a thread once a follow-up commit matches its suggestion, but the comment itself stays in place.
- Added a new "New commits since last review" section to `pr-sweep.sh`: flags any open PR where the last commit postdates the last actual review (`pulls/<pr>/reviews`), deliberately excluding `pulls/<pr>/comments`/issue comments since those include CI status bots (`sonarqubecloud`, `github-actions`) that post after a real review and would otherwise mask a genuinely unreviewed push.
- `SKILL.md` documents both patterns plus the workflow for acting on a flagged PR: isolate just the new commits, diff only that slice, and post findings with `gh pr review <pr> --comment` — not `--approve`, which fails with "Can not approve your own pull request" whenever the authenticated `gh` user is also the PR author (true for every maintenance PR in this repo).
- `README.md` updated to match.

Derived from a live session where these exact gaps caused real friction: `pr-sweep.sh` flagged 4 PRs as having outstanding review comments that were actually already resolved, and a follow-up "check for new pushes since last review" request required hand-rolling the commit-vs-review timestamp comparison that's now baked into the script.

## Test plan
- [x] `bash -n scripts/github/pr-sweep.sh` — syntax check passes
- [x] Ran `scripts/github/pr-sweep.sh` against the live repo — new "Unresolved review threads" and "New commits since last review" sections both render correctly and match manual GraphQL/REST verification done in the same session

## Summary by Sourcery

Improve the PR sweep script to focus on unresolved review threads and detect new commits pushed after the last review for all open PRs.

New Features:
- Add a "New commits since last review" section to pr-sweep.sh that flags open PRs with commits newer than their last review.
- Surface unresolved review-thread counts in pr-sweep.sh using GraphQL thread resolution instead of raw comment counts.

Enhancements:
- Align SKILL documentation with the updated pr-sweep.sh behavior and recommended workflow for reviewing new pushes.
- Update the scripts/github README to describe the new unresolved-thread and new-commit checks in pr-sweep.sh.

Documentation:
- Expand SKILL.md with guidance on using thread resolution over comment counts and on reviewing new commits since the last review, including appropriate gh review commands.
- Refresh README.md to reflect pr-sweep.sh's enhanced reporting of unresolved threads and post-review commits.