### PR TITLE
Configure sonar.tests so SonarCloud stops flagging test files

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -98,5 +98,6 @@ jobs:
             -Dsonar.projectKey=kejhy93_ProteinFolding
             -Dsonar.organization=kejhy93
             -Dsonar.python.coverage.reportPaths=coverage.xml
+            -Dsonar.tests=tests
           # When you need the analysis to take place in a directory other than the one from which it was launched, default is .
           projectBaseDir: .


### PR DESCRIPTION
…roduction rules

## Summary by Sourcery

CI:
- Update SonarCloud GitHub Actions workflow to set sonar.tests to the tests directory so test files are not flagged as production code.